### PR TITLE
EKIRJASTO-619-Use-Asap-font

### DIFF
--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LinkButton renders correct element 1`] = `
 .emotion-0 {
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -71,7 +71,7 @@ exports[`NavButton renders correct element 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: var(--theme-ui-colors-ui-white);
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -140,7 +140,7 @@ exports[`NavButton renders correct element 1`] = `
 
 exports[`variants filled (default) 1`] = `
 .emotion-0 {
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -206,7 +206,7 @@ exports[`variants filled (default) 1`] = `
 
 exports[`variants ghost 1`] = `
 .emotion-0 {
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 1.5;
@@ -286,7 +286,7 @@ exports[`variants link 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   background-color: transparent;
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 1rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Select.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`select matches snapshot 1`] = `
   padding-bottom: 4px;
   border: 1px solid #bdbdbd;
   border-radius: 2px;
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextInput renders properly and passes styles through 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;
@@ -55,7 +55,7 @@ exports[`type textarea renders properly and passes styles throug 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`renders as expected 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: 'Open Sans',Helvetica,Arial,sans-serif;
+  font-family: Asap,sans-serif;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -2,6 +2,8 @@ const styles = {
   /**
    * root wraps the whole app and these are therefore
    * the default styles
+   * Using fonts as per e-kirjasto visual guide
+   * Joona Kupe 2025
    */
   root: {
     fontFamily: "body",
@@ -9,7 +11,12 @@ const styles = {
     fontSize: 0,
     lineHeight: 3,
     color: "ui.black"
-  }
+  },
+  fonts: {
+    body: "Asap,sans-serif",
+    heading: "Asap,sans-serif",
+    monospace: "Menlo, monospace"
+  },
 };
 
 export default styles;

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -16,7 +16,7 @@ const styles = {
     body: "Asap,sans-serif",
     heading: "Asap,sans-serif",
     monospace: "Menlo, monospace"
-  },
+  }
 };
 
 export default styles;

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,7 +1,7 @@
 const typography = {
   fonts: {
-    body: "'Open Sans',Helvetica,Arial,sans-serif",
-    heading: "'Open Sans',Helvetica,Arial,sans-serif",
+    body: "Asap,sans-serif",
+    heading: "Asap,sans-serif",
     monospace: "Menlo, monospace"
   },
   fontSizes: {


### PR DESCRIPTION
Use Asap as E-kirjasto web-patron font

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
