### PR TITLE
Revert base path implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 ### UNRELEASED CHANGES
 
 - E-kirjasto visual implementation
+- Hardcoded basepath removed

--- a/community-config.yml
+++ b/community-config.yml
@@ -1,7 +1,7 @@
 # Set an instance name to be used in bug tracking and for other debugging purposes.
 # This is not patron-facing, so call it something that will be meaningful to you when
 # reviewing bugs, especially if you operate multiple instances.
-instance_name: Patron Web Catalog - Community Demo
+instance_name: E-kirjasto web -dev
 
 # APP MEDIA SUPPORT
 # Each entry has a setting of "show", "redirect" or "show-and-redirect".

--- a/community-config.yml
+++ b/community-config.yml
@@ -73,4 +73,4 @@ companion_app: simplye
 # Or define the catalog root and shortname for each library on this instance.
 # the homepage of the library will then be at https://domain.com/:library/
 libraries:
-  E-kirjasto: https://lib-dev.e-kirjasto.fi/authentication_document
+  ekirjasto: https://lib-dev.e-kirjasto.fi/ekirjasto/authentication_document

--- a/next.config.js
+++ b/next.config.js
@@ -123,7 +123,6 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true"
 });
 module.exports = {
-  basePath: '/web',
   ...withTM(withBundleAnalyzer(config)),
   distDir: "_next",
   generateBuildId: async () => {


### PR DESCRIPTION
## Description

Remove basePath implementation, as not needed.
Static assets paths are now working properly.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
```
git switch revert-basePath-implementation
npm run build
npm run start
open http://localhost:3000

```
<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
