### PR TITLE
Magazines reader basic implementation

### DIFF
--- a/src/auth/LoginWrapper.tsx
+++ b/src/auth/LoginWrapper.tsx
@@ -1,5 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { jsx } from "theme-ui";
 import * as React from "react";
 import useLibraryContext from "../components/context/LibraryContext";

--- a/src/components/BreadcrumbBar.tsx
+++ b/src/components/BreadcrumbBar.tsx
@@ -1,5 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { jsx } from "theme-ui";
 import * as React from "react";
 import Link from "./Link";

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { jsx } from "theme-ui";
 import * as React from "react";
 import { LibraryData } from "../interfaces";
@@ -111,6 +113,22 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
           {libraryWebsite.title ?? `${libraryName} Home`}
         </AnchorButton>
       )}
+      <NavButton
+        variant="ghost"
+        color="ui.black"
+        href="/magazines"
+        sx={{ mr: 1 }}
+      >
+        Magazines (logged in users)
+      </NavButton>
+      <NavButton
+        variant="ghost"
+        color="ui.black"
+        href="/magazines-preview"
+        sx={{ mr: 1 }}
+      >
+        Magazines (anonymous users)
+      </NavButton>
       <NavButton
         variant="ghost"
         color="ui.black"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,5 +1,7 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
 import { jsx } from "theme-ui";
 import { Themed } from "@theme-ui/mdx";
 import * as React from "react";
@@ -13,9 +15,10 @@ export const CONTENT_ID = "cpw-content";
 
 interface Props {
   children: React.ReactNode;
+  hideFooter?: boolean;
 }
 
-const Layout = ({ children }: Props) => {
+const Layout = ({ children, hideFooter = false }: Props) => {
   return (
     <Themed.root
       sx={{ display: "flex", flexDirection: "column", minHeight: "100vh" }}
@@ -34,7 +37,7 @@ const Layout = ({ children }: Props) => {
       >
         <ErrorBoundary>{children}</ErrorBoundary>
       </main>
-      <Footer sx={{ width: "100%" }} />
+      {!hideFooter && <Footer sx={{ width: "100%" }} />}
     </Themed.root>
   );
 };

--- a/src/components/LayoutPage.tsx
+++ b/src/components/LayoutPage.tsx
@@ -5,12 +5,20 @@ import { AppProps } from "dataflow/withAppProps";
 
 /* LayoutPage is a Page with Header and Footer from Layout, this should be used to wrap pages within the app with sitewide navigation. */
 
-type AppPropsWithChildren = AppProps & { children?: React.ReactNode };
+type AppPropsWithChildren = AppProps & {
+  children?: React.ReactNode;
+  hideFooter?: boolean;
+};
 
-const LayoutPage = ({ children, library, error }: AppPropsWithChildren) => {
+const LayoutPage = ({
+  children,
+  library,
+  error,
+  hideFooter
+}: AppPropsWithChildren) => {
   return (
     <Page library={library} error={error}>
-      <Layout>{children}</Layout>
+      <Layout hideFooter={hideFooter}>{children}</Layout>
     </Page>
   );
 };

--- a/src/components/MagazineCard.tsx
+++ b/src/components/MagazineCard.tsx
@@ -1,0 +1,167 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { AspectRatio } from "@theme-ui/components";
+import { Text, H3 } from "./Text";
+import LazyImage from "./LazyImage";
+import { MagazineIssue } from "../types/magazines";
+import { truncateString } from "../utils/string";
+
+export const MAGAZINE_WIDTH = 187;
+export const MAGAZINE_HEIGHT = 365;
+
+type ImageLoadState = "loading" | "error" | "success";
+
+const MagazineCover: React.FC<{
+  issue: MagazineIssue;
+  className?: string;
+}> = ({ issue, className }) => {
+  const [state, setState] = React.useState<ImageLoadState>("loading");
+
+  const handleError = () => setState("error");
+  const handleLoad = () => setState("success");
+
+  return (
+    <div
+      className={className}
+      sx={{
+        overflow: "hidden",
+        position: "relative",
+        "&>div": {
+          height: "100%"
+        }
+      }}
+      aria-label={`Cover of magazine: ${issue.title?.name || issue.name}`}
+      role="img"
+    >
+      <AspectRatio
+        ratio={2 / 3}
+        sx={{
+          width: "100%",
+          height: "100%",
+          p: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "ui.gray.lightWarm"
+        }}
+      >
+        {/* Fallback content when no image */}
+        <div sx={{ textAlign: "center", p: 2 }}>
+          <Text sx={{ fontSize: 0, color: "ui.gray.dark" }}>
+            {issue.title?.name || issue.name}
+          </Text>
+        </div>
+      </AspectRatio>
+      {issue.coverUrl && (
+        <LazyImage
+          alt={`Cover of magazine: ${issue.title?.name || issue.name}`}
+          src={issue.coverUrl}
+          onError={handleError}
+          onLoad={handleLoad}
+          sx={{
+            width: "100%",
+            height: "100%",
+            objectFit: "contain",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            opacity: state === "success" ? 1 : 0,
+            transition: "all 0.1s ease-in"
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const MagazineCard = React.forwardRef<
+  HTMLLIElement,
+  {
+    issue: MagazineIssue;
+    className?: string;
+    onClick?: (issue: MagazineIssue) => void;
+  }
+>(({ issue, className, onClick }, ref) => {
+  const twoLines = 42;
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick(issue);
+    }
+  };
+
+  return (
+    <li
+      className={className}
+      ref={ref}
+      sx={{
+        listStyle: "none",
+        display: "flex",
+        flexDirection: "column",
+        flex: `0 0 ${MAGAZINE_WIDTH}px`,
+        height: MAGAZINE_HEIGHT,
+        mx: 2,
+        cursor: onClick ? "pointer" : "default"
+      }}
+    >
+      <button
+        onClick={onClick ? handleClick : undefined}
+        disabled={!onClick}
+        aria-label={
+          onClick ? `Open ${issue.title?.name || issue.name}` : undefined
+        }
+        sx={{
+          border: "none",
+          background: "transparent",
+          padding: 0,
+          cursor: onClick ? "pointer" : "default",
+          width: "100%",
+          textAlign: "left",
+          "&:hover": onClick
+            ? {
+                transform: "scale(1.02)",
+                transition: "transform 0.2s ease-in-out"
+              }
+            : {},
+          "&:focus": onClick
+            ? {
+                outline: "2px solid",
+                outlineColor: "ui.blue.focus",
+                outlineOffset: "2px"
+              }
+            : {},
+          "&:disabled": {
+            cursor: "default"
+          }
+        }}
+      >
+        <MagazineCover issue={issue} />
+        <div sx={{ flex: "1 1 auto" }} />
+        <H3 sx={{ m: 0, mt: 1, fontSize: -1 }}>
+          {truncateString(issue.title?.name || issue.name, twoLines, false)}
+        </H3>
+        {issue.name !== issue.title?.name && (
+          <Text sx={{ fontSize: -1, color: "ui.gray.dark" }}>
+            {truncateString(issue.name, twoLines, false)}
+          </Text>
+        )}
+        {issue.publicationDate && (
+          <Text sx={{ fontSize: -2, color: "ui.gray.medium" }}>
+            {new Date(issue.publicationDate).toLocaleDateString()}
+          </Text>
+        )}
+      </button>
+    </li>
+  );
+});
+
+MagazineCard.displayName = "MagazineCard";
+
+export default MagazineCard;

--- a/src/components/MagazineFilters.tsx
+++ b/src/components/MagazineFilters.tsx
@@ -1,0 +1,103 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import Select, { Label } from "./Select";
+import {
+  MagazineTitle,
+  MagazineCategory,
+  MagazineFilters
+} from "../types/magazines";
+
+interface MagazineFiltersProps {
+  titles: MagazineTitle[];
+  categories: MagazineCategory[];
+  filters: MagazineFilters;
+  onFiltersChange: (filters: MagazineFilters) => void;
+  className?: string;
+}
+
+const MagazineFiltersComponent: React.FC<MagazineFiltersProps> = ({
+  titles,
+  categories,
+  filters,
+  onFiltersChange,
+  className
+}) => {
+  const handleTitleChange = (e: React.FormEvent<HTMLSelectElement>) => {
+    const selectedTitle = e.currentTarget.value || undefined;
+    onFiltersChange({
+      ...filters,
+      selectedTitle
+    });
+  };
+
+  const handleCategoryChange = (e: React.FormEvent<HTMLSelectElement>) => {
+    const selectedCategory = e.currentTarget.value || undefined;
+    onFiltersChange({
+      ...filters,
+      selectedCategory
+    });
+  };
+
+  return (
+    <div
+      className={className}
+      sx={{
+        display: "flex",
+        flexDirection: ["column", "row"],
+        gap: 3,
+        px: [2, 3, 4],
+        py: 3,
+        borderBottom: "1px solid",
+        borderColor: "ui.gray.light",
+        backgroundColor: "ui.gray.extraExtraLight"
+      }}
+    >
+      <div sx={{ flex: 1, minWidth: "200px" }}>
+        <Label htmlFor="magazine-title-filter" sx={{ display: "block", mb: 1 }}>
+          Valitse lehti...
+        </Label>
+        <Select
+          id="magazine-title-filter"
+          value={filters.selectedTitle || ""}
+          onChange={handleTitleChange}
+          onBlur={handleTitleChange}
+        >
+          <option value="">Kaikki lehdet</option>
+          {titles.map(title => (
+            <option key={title.id} value={title.id}>
+              {title.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+
+      <div sx={{ flex: 1, minWidth: "200px" }}>
+        <Label
+          htmlFor="magazine-category-filter"
+          sx={{ display: "block", mb: 1 }}
+        >
+          Valitse aihelue...
+        </Label>
+        <Select
+          id="magazine-category-filter"
+          value={filters.selectedCategory || ""}
+          onChange={handleCategoryChange}
+          onBlur={handleCategoryChange}
+        >
+          <option value="">Kaikki aiheet</option>
+          {categories.map(category => (
+            <option key={category.id} value={category.id}>
+              {category.name}
+            </option>
+          ))}
+        </Select>
+      </div>
+    </div>
+  );
+};
+
+export default MagazineFiltersComponent;

--- a/src/components/MagazineGrid.tsx
+++ b/src/components/MagazineGrid.tsx
@@ -1,0 +1,60 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import MagazineCard from "./MagazineCard";
+import { MagazineIssue } from "../types/magazines";
+
+interface MagazineGridProps {
+  issues: MagazineIssue[];
+  onIssueClick?: (issue: MagazineIssue) => void;
+  className?: string;
+}
+
+const MagazineGrid: React.FC<MagazineGridProps> = ({
+  issues,
+  onIssueClick,
+  className
+}) => {
+  if (issues.length === 0) {
+    return (
+      <div
+        className={className}
+        sx={{
+          textAlign: "center",
+          py: 4,
+          color: "ui.gray.dark"
+        }}
+      >
+        <p>Ei lehtiä saatavilla valituilla suodattimilla.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      sx={{
+        display: "grid",
+        gridTemplateColumns: [
+          "repeat(auto-fill, minmax(150px, 1fr))",
+          "repeat(auto-fill, minmax(180px, 1fr))",
+          "repeat(auto-fill, minmax(187px, 1fr))"
+        ],
+        gap: [2, 3, 4],
+        px: [2, 3, 4],
+        py: 3
+      }}
+    >
+      {issues.map(issue => (
+        <div key={issue.id} sx={{ display: "flex", justifyContent: "center" }}>
+          <MagazineCard issue={issue} onClick={onIssueClick} />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MagazineGrid;

--- a/src/components/MagazineIssuesByYear.tsx
+++ b/src/components/MagazineIssuesByYear.tsx
@@ -1,0 +1,148 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { H2 } from "./Text";
+import MagazineCard from "./MagazineCard";
+import { MagazineIssue, MagazineTitle } from "../types/magazines";
+
+interface MagazineIssuesByYearProps {
+  title: MagazineTitle;
+  issues: MagazineIssue[];
+  onIssueClick?: (issue: MagazineIssue) => void;
+  className?: string;
+}
+
+const MagazineIssuesByYear: React.FC<MagazineIssuesByYearProps> = ({
+  title,
+  issues,
+  onIssueClick,
+  className
+}) => {
+  // Group issues by year
+  const issuesByYear = React.useMemo(() => {
+    const grouped: { [year: string]: MagazineIssue[] } = {};
+
+    issues.forEach(issue => {
+      if (issue.publicationDate) {
+        const year = new Date(issue.publicationDate).getFullYear().toString();
+        if (!grouped[year]) {
+          grouped[year] = [];
+        }
+        grouped[year].push(issue);
+      }
+    });
+
+    // Sort issues within each year by publication date (newest first)
+    Object.keys(grouped).forEach(year => {
+      grouped[year].sort((a, b) => {
+        const dateA = new Date(a.publicationDate || 0);
+        const dateB = new Date(b.publicationDate || 0);
+        return dateB.getTime() - dateA.getTime();
+      });
+    });
+
+    return grouped;
+  }, [issues]);
+
+  // Get years sorted in descending order (newest first)
+  const years = Object.keys(issuesByYear).sort(
+    (a, b) => parseInt(b) - parseInt(a)
+  );
+
+  if (issues.length === 0) {
+    return (
+      <div
+        className={className}
+        sx={{
+          textAlign: "center",
+          py: 4,
+          color: "ui.gray.dark"
+        }}
+      >
+        <p>Ei numeroita saatavilla tälle lehdelle.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      {/* Magazine title and info */}
+      <div sx={{ px: [3, 5], mt: 4, mb: 3 }}>
+        <H2>{title.name}</H2>
+        {title.publisher && (
+          <p sx={{ color: "ui.gray.dark", mt: 1 }}>
+            Kustantaja: {title.publisher}
+          </p>
+        )}
+        {title.language && (
+          <div
+            sx={{
+              display: "inline-block",
+              backgroundColor: "ui.gray.extraLight",
+              px: 2,
+              py: 1,
+              borderRadius: 1,
+              fontSize: -1,
+              mt: 2
+            }}
+          >
+            {title.language === "fi"
+              ? "suomi"
+              : title.language === "sv"
+              ? "svenska"
+              : title.language === "en"
+              ? "english"
+              : title.language}
+          </div>
+        )}
+      </div>
+
+      {/* Issues grouped by year */}
+      {years.map(year => (
+        <div key={year} sx={{ mb: 4 }}>
+          {/* Year header */}
+          <div
+            sx={{
+              px: [3, 5],
+              py: 2,
+              backgroundColor: "ui.gray.extraLight",
+              borderLeft: "4px solid",
+              borderColor: "brand.primary"
+            }}
+          >
+            <H2 sx={{ m: 0, fontSize: 2 }}>{year}</H2>
+          </div>
+
+          {/* Issues grid for this year */}
+          <div
+            sx={{
+              display: "grid",
+              gridTemplateColumns: [
+                "repeat(auto-fill, minmax(150px, 1fr))",
+                "repeat(auto-fill, minmax(180px, 1fr))",
+                "repeat(auto-fill, minmax(187px, 1fr))"
+              ],
+              gap: [2, 3, 4],
+              px: [2, 3, 4],
+              py: 3
+            }}
+          >
+            {issuesByYear[year].map(issue => (
+              <div
+                key={issue.id}
+                sx={{ display: "flex", justifyContent: "center" }}
+              >
+                <MagazineCard issue={issue} onClick={onIssueClick} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MagazineIssuesByYear;

--- a/src/components/MagazineTitleCard.tsx
+++ b/src/components/MagazineTitleCard.tsx
@@ -1,0 +1,163 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { AspectRatio } from "@theme-ui/components";
+import { Text, H3 } from "./Text";
+import LazyImage from "./LazyImage";
+import { MagazineTitle } from "../types/magazines";
+import { truncateString } from "../utils/string";
+
+export const MAGAZINE_TITLE_WIDTH = 187;
+export const MAGAZINE_TITLE_HEIGHT = 365;
+
+type ImageLoadState = "loading" | "error" | "success";
+
+const MagazineTitleCover: React.FC<{
+  title: MagazineTitle;
+  latestIssue?: any;
+  className?: string;
+}> = ({ title, latestIssue, className }) => {
+  const [state, setState] = React.useState<ImageLoadState>("loading");
+
+  const handleError = () => setState("error");
+  const handleLoad = () => setState("success");
+
+  // Use the latest issue's cover if available
+  const coverUrl = latestIssue?.coverUrl;
+
+  return (
+    <div
+      className={className}
+      sx={{
+        overflow: "hidden",
+        position: "relative",
+        "&>div": {
+          height: "100%"
+        }
+      }}
+      aria-label={`Cover of magazine: ${title.name}`}
+      role="img"
+    >
+      <AspectRatio
+        ratio={2 / 3}
+        sx={{
+          width: "100%",
+          height: "100%",
+          p: 1,
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          alignItems: "center",
+          backgroundColor: "ui.gray.lightWarm"
+        }}
+      >
+        {/* Fallback content when no image */}
+        <div sx={{ textAlign: "center", p: 2 }}>
+          <Text sx={{ fontSize: 0, color: "ui.gray.dark" }}>{title.name}</Text>
+        </div>
+      </AspectRatio>
+      {coverUrl && (
+        <LazyImage
+          alt={`Cover of magazine: ${title.name}`}
+          src={coverUrl}
+          onError={handleError}
+          onLoad={handleLoad}
+          sx={{
+            width: "100%",
+            height: "100%",
+            objectFit: "contain",
+            position: "absolute",
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            opacity: state === "success" ? 1 : 0,
+            transition: "all 0.1s ease-in"
+          }}
+        />
+      )}
+    </div>
+  );
+};
+
+const MagazineTitleCard = React.forwardRef<
+  HTMLLIElement,
+  {
+    title: MagazineTitle;
+    latestIssue?: any;
+    className?: string;
+    onClick?: (title: MagazineTitle) => void;
+  }
+>(({ title, latestIssue, className, onClick }, ref) => {
+  const twoLines = 42;
+
+  const handleClick = () => {
+    if (onClick) {
+      onClick(title);
+    }
+  };
+
+  return (
+    <li
+      className={className}
+      ref={ref}
+      sx={{
+        listStyle: "none",
+        display: "flex",
+        flexDirection: "column",
+        flex: `0 0 ${MAGAZINE_TITLE_WIDTH}px`,
+        height: MAGAZINE_TITLE_HEIGHT,
+        mx: 2,
+        cursor: onClick ? "pointer" : "default"
+      }}
+    >
+      <button
+        onClick={onClick ? handleClick : undefined}
+        disabled={!onClick}
+        aria-label={onClick ? `View ${title.name} issues` : undefined}
+        sx={{
+          border: "none",
+          background: "transparent",
+          padding: 0,
+          cursor: onClick ? "pointer" : "default",
+          width: "100%",
+          textAlign: "left",
+          "&:hover": onClick
+            ? {
+                transform: "scale(1.02)",
+                transition: "transform 0.2s ease-in-out"
+              }
+            : {},
+          "&:focus": onClick
+            ? {
+                outline: "2px solid",
+                outlineColor: "ui.blue.focus",
+                outlineOffset: "2px"
+              }
+            : {},
+          "&:disabled": {
+            cursor: "default"
+          }
+        }}
+      >
+        <MagazineTitleCover title={title} latestIssue={latestIssue} />
+        <div sx={{ flex: "1 1 auto" }} />
+        <H3 sx={{ m: 0, mt: 1, fontSize: -1 }}>
+          {truncateString(title.name, twoLines, false)}
+        </H3>
+        {title.publisher && (
+          <Text sx={{ fontSize: -1, color: "ui.gray.dark" }}>
+            {truncateString(title.publisher, twoLines, false)}
+          </Text>
+        )}
+      </button>
+    </li>
+  );
+});
+
+MagazineTitleCard.displayName = "MagazineTitleCard";
+
+export default MagazineTitleCard;

--- a/src/components/MagazineTitleGrid.tsx
+++ b/src/components/MagazineTitleGrid.tsx
@@ -1,0 +1,66 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import MagazineTitleCard from "./MagazineTitleCard";
+import { MagazineTitle } from "../types/magazines";
+
+interface MagazineTitleGridProps {
+  titles: MagazineTitle[];
+  latestIssues: { [titleId: string]: any };
+  onTitleClick?: (title: MagazineTitle) => void;
+  className?: string;
+}
+
+const MagazineTitleGrid: React.FC<MagazineTitleGridProps> = ({
+  titles,
+  latestIssues,
+  onTitleClick,
+  className
+}) => {
+  if (titles.length === 0) {
+    return (
+      <div
+        className={className}
+        sx={{
+          textAlign: "center",
+          py: 4,
+          color: "ui.gray.dark"
+        }}
+      >
+        <p>Ei lehtiä saatavilla valituilla suodattimilla.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className={className}
+      sx={{
+        display: "grid",
+        gridTemplateColumns: [
+          "repeat(auto-fill, minmax(150px, 1fr))",
+          "repeat(auto-fill, minmax(180px, 1fr))",
+          "repeat(auto-fill, minmax(187px, 1fr))"
+        ],
+        gap: [2, 3, 4],
+        px: [2, 3, 4],
+        py: 3
+      }}
+    >
+      {titles.map(title => (
+        <div key={title.id} sx={{ display: "flex", justifyContent: "center" }}>
+          <MagazineTitleCard
+            title={title}
+            latestIssue={latestIssues[title.id]}
+            onClick={onTitleClick}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default MagazineTitleGrid;

--- a/src/config/magazines.ts
+++ b/src/config/magazines.ts
@@ -1,0 +1,56 @@
+/**
+ * Centralized configuration for magazine-related URLs and settings
+ */
+
+// Base URLs for the magazine reader interface
+const MAGAZINE_READER_URLS = {
+  production: "https://e-kirjasto.epaper.fi",
+  playground: "https://e-kirjasto-playground.epaper.fi"
+} as const;
+
+// API URLs for magazine catalog data
+const MAGAZINE_API_URLS = {
+  production: "https://e-kirjasto.epaper.fi/feed/catalog",
+  playground: "https://e-kirjasto-playground.epaper.fi/feed/catalog"
+} as const;
+
+/**
+ * Get the magazine reader base URL based on environment
+ */
+export function getMagazineReaderUrl(): string {
+  return process.env.NODE_ENV === "production"
+    ? MAGAZINE_READER_URLS.production
+    : MAGAZINE_READER_URLS.playground;
+}
+
+/**
+ * Get the magazine API URL based on environment
+ */
+export function getMagazineApiUrl(): string {
+  return process.env.NODE_ENV === "production"
+    ? MAGAZINE_API_URLS.production
+    : MAGAZINE_API_URLS.playground;
+}
+
+/**
+ * Get the allowed origin for magazine iframe communication
+ */
+export function getMagazineAllowedOrigin(): string {
+  const baseUrl = getMagazineReaderUrl();
+  return process.env.NEXT_PUBLIC_MAGAZINES_ORIGIN || new URL(baseUrl).origin;
+}
+
+/**
+ * Configuration constants
+ */
+export const MAGAZINE_CONFIG = {
+  // Storage key prefix for saving last visited paths
+  STORAGE_KEY_PREFIX: "magazines:lastPath:",
+
+  // Default iframe permissions
+  IFRAME_ALLOW: "fullscreen; clipboard-read; clipboard-write",
+
+  // Default iframe sandbox permissions
+  IFRAME_SANDBOX:
+    "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+} as const;

--- a/src/hooks/useMagazines.ts
+++ b/src/hooks/useMagazines.ts
@@ -1,0 +1,141 @@
+import * as React from "react";
+import useSWR from "swr";
+import useUser from "components/context/UserContext";
+import { MagazinesResponse, MagazineFilters } from "../types/magazines";
+import { getMagazineApiUrl } from "../config/magazines";
+
+function getLocalizedText(text: any, preferredLang = "fi"): string {
+  if (typeof text === "string") {
+    return text;
+  }
+  if (typeof text === "object" && text !== null) {
+    return text[preferredLang] || text.fi || text.en || text.sv || String(text);
+  }
+  return String(text || "");
+}
+
+function transformApiResponse(apiData: any): MagazinesResponse {
+  const titles = (apiData.titles || []).map((title: any) => ({
+    id: title.uuid,
+    name: getLocalizedText(title.name),
+    path: title.path,
+    publisher: getLocalizedText(title.publisher),
+    language: title.language,
+    categoryIds: title.categoryIds
+  }));
+
+  const categories = (apiData.categories || []).map((category: any) => ({
+    id: category.id,
+    name: getLocalizedText(category.name),
+    path: category.path
+  }));
+
+  const issues: any[] = [];
+  (apiData.titles || []).forEach((title: any) => {
+    (title.issues || []).forEach((issue: any) => {
+      const transformedTitle = titles.find((t: any) => t.id === title.uuid);
+
+      issues.push({
+        id: issue.uuid,
+        name: issue.issueCode || getLocalizedText(issue.name),
+        path: `${title.path}/${issue.uuid}`,
+        publicationDate: issue.publishedAt,
+        coverUrl:
+          issue.coverUrl?.md || issue.coverUrl?.xl || issue.coverUrl?.sm,
+        title: transformedTitle
+      });
+    });
+  });
+
+  return {
+    titles,
+    categories,
+    issues
+  };
+}
+
+async function fetchMagazines(
+  url: string,
+  token?: string
+): Promise<MagazinesResponse> {
+  const headers: HeadersInit = {
+    Accept: "application/json",
+    "Content-Type": "application/json"
+  };
+
+  if (token) {
+    headers["Authorization"] = token;
+  }
+
+  const response = await fetch(url, {
+    method: "GET",
+    headers,
+    mode: "cors"
+  });
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch magazines: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const apiData = await response.json();
+  return transformApiResponse(apiData);
+}
+
+export default function useMagazines() {
+  const { token } = useUser();
+  const [filters, setFilters] = React.useState<MagazineFilters>({});
+
+  const magazineApiUrl = getMagazineApiUrl();
+
+  const { data, error, isValidating } = useSWR<MagazinesResponse, Error>(
+    `magazines-${magazineApiUrl}-${token || "no-token"}`,
+    () => fetchMagazines(magazineApiUrl, token),
+    {
+      // Refresh every 5 minutes
+      refreshInterval: 5 * 60 * 1000,
+      revalidateOnFocus: true,
+      errorRetryCount: 3,
+      errorRetryInterval: 5000,
+      shouldRetryOnError: true
+    }
+  );
+
+  const filteredIssues = React.useMemo(() => {
+    if (!data?.issues) return [];
+
+    let filtered = data.issues;
+
+    if (filters.selectedTitle) {
+      filtered = filtered.filter(
+        issue => issue.title?.id === filters.selectedTitle
+      );
+    }
+
+    if (filters.selectedCategory) {
+      const titlesInCategory =
+        data.titles
+          ?.filter(title =>
+            title.categoryIds?.includes(filters.selectedCategory!)
+          )
+          .map(title => title.id) || [];
+
+      filtered = filtered.filter(
+        issue => issue.title?.id && titlesInCategory.includes(issue.title.id)
+      );
+    }
+
+    return filtered;
+  }, [data?.issues, data?.titles, filters]);
+
+  return {
+    titles: data?.titles || [],
+    categories: data?.categories || [],
+    issues: filteredIssues,
+    filters,
+    setFilters,
+    isLoading: isValidating,
+    error
+  };
+}

--- a/src/pages/[library]/magazines-preview/index.tsx
+++ b/src/pages/[library]/magazines-preview/index.tsx
@@ -1,0 +1,200 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { NextPage, GetStaticProps, GetStaticPaths } from "next";
+import LayoutPage from "components/LayoutPage";
+import withAppProps, { AppProps } from "dataflow/withAppProps";
+import BreadcrumbBar from "components/BreadcrumbBar";
+import Head from "next/head";
+import { H1 } from "components/Text";
+import MagazineFilters from "components/MagazineFilters";
+import MagazineTitleGrid from "components/MagazineTitleGrid";
+import MagazineIssuesByYear from "components/MagazineIssuesByYear";
+import LoadingIndicator from "components/LoadingIndicator";
+import useMagazines from "hooks/useMagazines";
+import { MagazineIssue, MagazineTitle } from "types/magazines";
+import { getMagazineReaderUrl } from "config/magazines";
+
+const MagazinesPreviewContent: React.FC = () => {
+  const {
+    titles,
+    categories,
+    issues,
+    filters,
+    setFilters,
+    isLoading,
+    error
+  } = useMagazines();
+
+  const [
+    selectedTitle,
+    setSelectedTitle
+  ] = React.useState<MagazineTitle | null>(null);
+
+  const handleTitleClick = (title: MagazineTitle) => {
+    setSelectedTitle(title);
+  };
+
+  const handleBackToTitles = () => {
+    setSelectedTitle(null);
+  };
+
+  const handleIssueClick = (issue: MagazineIssue) => {
+    const path = issue.path.startsWith("/") ? issue.path : `/${issue.path}`;
+    const baseUrl = getMagazineReaderUrl();
+    const readerUrl = `${baseUrl}${path}`;
+
+    // @TODO: should be a login redirect, with the ability route the user back
+    // to the correct magazine after login...
+    console.log("Opening magazine:", { issue, readerUrl });
+  };
+
+  // Filter titles based on current filters
+  const filteredTitles = React.useMemo(() => {
+    let filtered = titles;
+
+    if (filters.selectedTitle) {
+      filtered = filtered.filter(title => title.id === filters.selectedTitle);
+    }
+
+    if (filters.selectedCategory) {
+      filtered = filtered.filter(title =>
+        title.categoryIds?.includes(filters.selectedCategory!)
+      );
+    }
+
+    return filtered;
+  }, [titles, filters]);
+
+  const selectedTitleIssues = React.useMemo(() => {
+    if (!selectedTitle) return [];
+    return issues.filter(issue => issue.title?.id === selectedTitle.id);
+  }, [issues, selectedTitle]);
+
+  const latestIssues = React.useMemo(() => {
+    const latest: { [titleId: string]: any } = {};
+    issues.forEach(issue => {
+      if (issue.title?.id) {
+        const titleId = issue.title.id;
+        if (
+          !latest[titleId] ||
+          new Date(issue.publicationDate || 0) >
+            new Date(latest[titleId].publicationDate || 0)
+        ) {
+          latest[titleId] = issue;
+        }
+      }
+    });
+    return latest;
+  }, [issues]);
+
+  if (error) {
+    return (
+      <div sx={{ textAlign: "center", py: 4 }}>
+        <p sx={{ color: "ui.error" }}>
+          Virhe ladattaessa lehtiä: {error.message}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        minHeight: "60vh"
+      }}
+    >
+      {/* Header with navigation */}
+      <div sx={{ px: [3, 5], mt: 4, mb: 3 }}>
+        {selectedTitle ? (
+          <div sx={{ display: "flex", alignItems: "center", gap: 3 }}>
+            <button
+              onClick={handleBackToTitles}
+              sx={{
+                background: "transparent",
+                border: "1px solid",
+                borderColor: "ui.gray.medium",
+                borderRadius: 1,
+                px: 3,
+                py: 2,
+                cursor: "pointer",
+                "&:hover": {
+                  backgroundColor: "ui.gray.extraLight"
+                }
+              }}
+            >
+              ← Takaisin lehtiin
+            </button>
+          </div>
+        ) : (
+          <H1>Lehdet</H1>
+        )}
+      </div>
+
+      {/* Show filters only on title list view */}
+      {!selectedTitle && (
+        <MagazineFilters
+          titles={titles}
+          categories={categories}
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
+      )}
+
+      {isLoading ? (
+        <div sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+          <LoadingIndicator />
+        </div>
+      ) : selectedTitle ? (
+        /* Show issues for selected title */
+        <MagazineIssuesByYear
+          title={selectedTitle}
+          issues={selectedTitleIssues}
+          onIssueClick={handleIssueClick}
+        />
+      ) : (
+        /* Show title grid */
+        <MagazineTitleGrid
+          titles={filteredTitles}
+          latestIssues={latestIssues}
+          onTitleClick={handleTitleClick}
+        />
+      )}
+    </div>
+  );
+};
+
+const MagazinesPreviewPage: NextPage<AppProps> = ({ library, error }) => {
+  return (
+    <LayoutPage library={library} error={error}>
+      <div
+        sx={{
+          flex: 1
+        }}
+      >
+        <Head>
+          <title>Lehdet - E-kirjasto</title>
+        </Head>
+        <BreadcrumbBar currentLocation="Lehdet" />
+        <MagazinesPreviewContent />
+      </div>
+    </LayoutPage>
+  );
+};
+
+export const getStaticProps: GetStaticProps = withAppProps();
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true
+  };
+};
+
+export default MagazinesPreviewPage;

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -1,0 +1,148 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { NextPage, GetStaticProps, GetStaticPaths } from "next";
+import LayoutPage from "components/LayoutPage";
+import withAppProps, { AppProps } from "dataflow/withAppProps";
+// import useUser from "components/context/UserContext";
+import useLogin from "auth/useLogin";
+import useLibraryContext from "components/context/LibraryContext";
+import {
+  getMagazineReaderUrl,
+  getMagazineAllowedOrigin,
+  MAGAZINE_CONFIG
+} from "config/magazines";
+import Head from "next/head";
+import BreadcrumbBar from "components/BreadcrumbBar";
+
+const MagazinesFixedContent: React.FC = () => {
+  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+  const token = "MOCK_TOKEN";
+  // const { token } = useUser();
+  const { initLogin } = useLogin();
+  const { slug } = useLibraryContext();
+
+  const storageKey = React.useMemo(
+    () => `${MAGAZINE_CONFIG.STORAGE_KEY_PREFIX}${slug ?? "default"}`,
+    [slug]
+  );
+
+  const [initialPath, setInitialPath] = React.useState<string | undefined>(
+    undefined
+  );
+
+  React.useEffect(() => {
+    try {
+      const saved = window.localStorage.getItem(storageKey) || undefined;
+      setInitialPath(saved);
+    } catch {
+      setInitialPath(undefined);
+    }
+  }, [storageKey]);
+
+  const handleMessage = React.useCallback(
+    (e: MessageEvent) => {
+      const allowedOrigin = getMagazineAllowedOrigin();
+      if (e.origin !== allowedOrigin || typeof e.data !== "string") return;
+
+      if (e.data === "ewl:unauthorized") {
+        if (token) {
+          iframeRef.current?.contentWindow?.postMessage(
+            `ewl:login:${token}`,
+            allowedOrigin
+          );
+        } else {
+          initLogin();
+        }
+        return;
+      }
+
+      if (e.data.startsWith("ewl:navigate:")) {
+        const path = e.data.slice("ewl:navigate:".length);
+        try {
+          window.localStorage.setItem(storageKey, path);
+        } catch {}
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        window?.dataLayer?.push({
+          event: "magazines_navigate",
+          magazines_path: path // eslint-disable-line camelcase
+        });
+      }
+    },
+    [initLogin, token, storageKey]
+  );
+
+  React.useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  const src = React.useMemo(() => {
+    const path = initialPath ?? "";
+    const baseUrl = getMagazineReaderUrl();
+    return `${baseUrl}${path}`;
+  }, [initialPath]);
+
+  // fixed-height layout where only the iframe scrolls and the footer is hidden
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        width: "100%",
+        flex: "1 1 auto",
+        minHeight: 0,
+        overflow: "hidden",
+        position: "relative"
+      }}
+    >
+      <iframe
+        ref={iframeRef}
+        title="Magazines (Fixed)"
+        src={src}
+        style={{
+          position: "absolute",
+          inset: 0,
+          width: "100%",
+          height: "100%",
+          border: 0
+        }}
+        allow={MAGAZINE_CONFIG.IFRAME_ALLOW}
+        sandbox={MAGAZINE_CONFIG.IFRAME_SANDBOX}
+      />
+    </div>
+  );
+};
+
+const MagazinesFixedPage: NextPage<AppProps> = ({ library, error }) => {
+  return (
+    <LayoutPage library={library} error={error} hideFooter>
+      <div
+        sx={{
+          flex: 1
+        }}
+      >
+        <Head>
+          <title>Lehdet - E-kirjasto</title>
+        </Head>
+        <BreadcrumbBar currentLocation="Lehdet" />
+        <MagazinesFixedContent />
+      </div>
+    </LayoutPage>
+  );
+};
+
+export const getStaticProps: GetStaticProps = withAppProps();
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  return {
+    paths: [],
+    fallback: true
+  };
+};
+
+export default MagazinesFixedPage;

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -121,17 +121,13 @@ const MagazinesFixedContent: React.FC = () => {
 const MagazinesFixedPage: NextPage<AppProps> = ({ library, error }) => {
   return (
     <LayoutPage library={library} error={error} hideFooter>
-      <div
-        sx={{
-          flex: 1
-        }}
-      >
+      <>
         <Head>
           <title>Lehdet - E-kirjasto</title>
         </Head>
         <BreadcrumbBar currentLocation="Lehdet" />
         <MagazinesFixedContent />
-      </div>
+      </>
     </LayoutPage>
   );
 };

--- a/src/types/magazines.ts
+++ b/src/types/magazines.ts
@@ -1,0 +1,59 @@
+// Magazine service related (epaper) TypeScript interfaces
+
+export interface MagazineTitle {
+  id: string;
+  name: string;
+  path: string;
+  publisher?: string;
+  language?: string;
+  categoryIds?: string[];
+}
+
+export interface MagazineIssue {
+  id: string;
+  name: string;
+  path: string;
+  publicationDate?: string;
+  coverUrl?: string;
+  title?: MagazineTitle;
+}
+
+export interface MagazineCategory {
+  id: string;
+  name: string;
+  path?: string;
+}
+
+// API Response structure based on the documentation
+export interface ApiMagazineEntry {
+  titles?: Array<{
+    id: string;
+    name: string;
+    path: string;
+    publisher?: string;
+    language?: string;
+    categoryIds?: string[];
+  }>;
+  issues?: Array<{
+    id: string;
+    name: string;
+    path: string;
+    publicationDate?: string;
+    coverUrl?: string;
+  }>;
+  categories?: Array<{
+    id: string;
+    name: string;
+  }>;
+}
+
+export interface MagazinesResponse {
+  titles?: MagazineTitle[];
+  issues?: MagazineIssue[];
+  categories?: MagazineCategory[];
+}
+
+export interface MagazineFilters {
+  selectedTitle?: string;
+  selectedCategory?: string;
+}


### PR DESCRIPTION
## Description

Basic implementation for embedding the ePaper magazine reader.

There are two new pages introduced with this:
- Authorized users magazine page: `[library]/magazines` where we embed the magazine reader from ePaper in an iframe, and do some messaging with the iframe, such as:
  - send the auth request to the magazine service with the `ewl:login:authToken` message
  - listen to the currently active page in the magazine service and store that locally so that we can open up the page from the same spot if user refreshes the page
- Unauthorized users magazine page: `[library]/magazines-preview` where we only list the magazine catalog through the ePress / ePaper api paths.

Additionally some minor things such as allowing the hiding of the footer so that we can make the magazine reader iframe embed work better.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

NOTE: `magazines-preview` path (for unauthenticated users) needs to be tested with CORS disabled by using for example the `--disable-web-security` flag for Chrome.

Also note that `magazines` path that embeds the actual ePress magazine reader as an iframe is currently skipping the actual authentication and using a mock token (`const token = "MOCK_TOKEN";`).

Also note that without having the same parent domain in the running app and the magazine reader, the user can't actually click to open any of the magazines due to browser security constraints. The final implementation will likely have the magazine reader running from an `.e-kirjasto.fi` subdomain, so this won't be an issue there.

## Things left to do

- Implement the ePaper token fetching logic: This requires an authenticated user session, so is not implemented yet. The logic will likely mirror how the mobile app fetches tokens.
- When a user opens a magazine from the `magazines-preview` route, they should somehow be redirected to the login page and from there back to the correct magazine after a successful login. This is also something that makes most sense to do after there is a working authentication solution.
- There should only be one "magazines" page in the UI and user should be presented the one relevant based on the login status of the user.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1

