### PR TITLE
EKIRJASTO-638-remove-distributed-by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - E-kirjasto visual implementation
 - Hardcoded basepath removed
+- Removed 'Distributed by:' from bookdetails

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -92,9 +92,6 @@ describe("book details page", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
     const providerName = fixtures.book.providerName as string;
-
-    expect(screen.getByText(providerName)).toBeInTheDocument();
-    expect(screen.getByText("Distributed by:")).toBeInTheDocument();
   });
 
   test("shows book format", () => {

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -91,7 +91,6 @@ describe("book details page", () => {
   test("shows provider name", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
-    const providerName = fixtures.book.providerName as string;
   });
 
   test("shows book format", () => {

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -96,10 +96,6 @@ export const BookDetails: React.FC = () => {
                 heading="Categories"
                 details={book.categories?.join(", ")}
               />
-              <DetailField
-                heading="Distributed by"
-                details={book.providerName}
-              />
               <DetailField heading="Book format" details={book.format} />
             </div>
             <ReportProblem book={book} />


### PR DESCRIPTION
## Description

Removed 'Distributed by' from book details page 

## How Can This Be Tested?

npm run dev
open a book
confirm that distributed by text will not show

- [ ] This change cannot be tested visually


<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
