### PR TITLE
EKIR-676 remove gray color

### DIFF
--- a/src/components/CancelOrReturn.tsx
+++ b/src/components/CancelOrReturn.tsx
@@ -42,13 +42,6 @@ const CancelOrReturn: React.FC<{
         onClick={() => cancelReservation(url)}
         loading={loading}
         loadingText={loadingText}
-        variant="ghost"
-        color="ui.gray.light"
-        sx={{
-          bg: "ui.gray.light",
-          color: "ui.gray.dark",
-          "&:hover,&:focus": { color: "ui.gray.dark" }
-        }}
       >
         {text}
       </Button>


### PR DESCRIPTION
## Description

Removes grey button color.

Users usually understand grey buttons to be inactive.

## How Can This Be Tested?

Borrow or reserve a book. The Cancel Reservation / Return button should be the same color as all the other buttons.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
