### PR TITLE
EKIRJASTO-649 Show more loan and hold information

### DIFF
--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -259,7 +259,9 @@ describe("ReservedBook", () => {
     });
     setup(<BookListItem book={reservedBookWithQueue} />);
     expect(
-      screen.getByText("5 patrons ahead of you in the queue.")
+      screen.getByText(
+        "You are in position 5 out of 23 in the queue. 0 out of 13 copies available."
+      )
     ).toBeInTheDocument();
   });
 });
@@ -321,7 +323,7 @@ describe("FulfillableBook", () => {
   test("displays correct title and subtitle and view details", () => {
     setup(<BookListItem book={downloadableBook} />);
     expect(
-      screen.getByText(`You have this book on loan until ${MOCK_DATE_STRING}.`)
+      screen.getByText(/You have this book on loan for /)
     ).toBeInTheDocument();
     expectReadMore();
   });

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -305,8 +305,11 @@ describe("reserved", () => {
       }
     });
     setup(<FulfillmentCard book={reservedBookWithQueue} />);
-    expect(screen.getByText("5 patrons ahead of you in the queue."))
-      .toBeInTheDocument;
+    expect(
+      screen.getByText(
+        "You are in position 5 out of 23 in the queue. 0 out of 13 copies available."
+      )
+    ).toBeInTheDocument;
   });
 });
 
@@ -411,7 +414,7 @@ describe("FulfillableBook", () => {
     setup(<FulfillmentCard book={downloadableBook} />);
     expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
     expect(
-      screen.getByText(`You have this book on loan until ${MOCK_DATE_STRING}.`)
+      screen.getByText(/You have this book on loan for /)
     ).toBeInTheDocument();
     expect(
       screen.queryByText("Ready to Read in Palace!")

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -44,7 +44,7 @@ test("extracts basic book info", () => {
   const borrowLink = factory.acquisitionLink({
     href: "http://example.com/borrow",
     rel: OPDSAcquisitionLink.BORROW_REL,
-    availability: { availability: "unavailable" },
+    availability: {},
     holds: { total: 20, position: 5 },
     copies: { total: 2, available: 0 },
     indirectAcquisitions: [

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -279,7 +279,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
 
   // Get the availability, holds and copies from the borrow link, and if there is no
   // borrow link, get it from the first possible acquisition link
-  const { availability, holds, copies } = borrowLink ?? acquisitionLinks[0]
+  const { availability, holds, copies } = borrowLink ?? acquisitionLinks[0];
 
   const format = bookIsAudiobook({ ...entry.unparsed, raw: entry.unparsed })
     ? "Audiobook"

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -250,8 +250,6 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
 
   const borrowLink = getBorrowLink(acquisitionLinks);
 
-  const { availability, holds, copies } = borrowLink ?? {};
-
   const openAccessLinks: FulfillmentLink[] = acquisitionLinks
     .filter(link => {
       return link.rel === OPDSAcquisitionLink.OPEN_ACCESS_REL;
@@ -279,6 +277,10 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     link => link.supportLevel !== "unsupported"
   );
 
+  // Get the availability, holds and copies from the borrow link, and if there is no
+  // borrow link, get it from the first possible acquisition link
+  const { availability, holds, copies } = borrowLink ?? acquisitionLinks[0]
+
   const format = bookIsAudiobook({ ...entry.unparsed, raw: entry.unparsed })
     ? "Audiobook"
     : inferEBookFormat(fulfillmentLinks, borrowLink);
@@ -300,10 +302,11 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     summary: entry.summary.content && DOMPurify.sanitize(entry.summary.content),
     imageUrl: imageUrl,
     availability: {
-      ...availability,
       // we type cast status because our internal types
       // are stricter than those in OPDSFeedParser.
-      status: availability?.status as BookAvailability
+      status: availability?.status as BookAvailability,
+      since: availability?.since,
+      until: availability?.until
     },
     holds: holds,
     copies: copies,

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -279,7 +279,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
 
   // Get the availability, holds and copies from the borrow link, and if there is no
   // borrow link, get it from the first possible acquisition link
-  const { availability, holds, copies } = borrowLink ?? acquisitionLinks[0];
+  const { availability, holds, copies } =
+    borrowLink ?? acquisitionLinks[0] ?? {};
 
   const format = bookIsAudiobook({ ...entry.unparsed, raw: entry.unparsed })
     ? "Audiobook"

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -44,19 +44,20 @@ export function availabilityString(book: AnyBook) {
   const status = book.status;
   const availableCopies = book.copies?.available;
   const totalCopies = book.copies?.total;
-  const queue =
-        typeof book.holds?.total === "number" ? book.holds.total : null;
+  const queue = typeof book.holds?.total === "number" ? book.holds.total : null;
 
   switch (status) {
     case "borrowable":
       return typeof availableCopies === "number" &&
         typeof totalCopies === "number"
-        ? `${availableCopies} out of ${totalCopies} copies available.`: null;
+        ? `${availableCopies} out of ${totalCopies} copies available.`
+        : null;
     case "reservable":
-     return typeof availableCopies === "number" &&
+      return typeof availableCopies === "number" &&
         typeof totalCopies === "number"
         ? `${availableCopies} out of ${totalCopies} copies available.${
-            queue !== null ? ` ${queue} patrons in the queue.`: ""}`
+            queue !== null ? ` ${queue} patrons in the queue.` : ""
+          }`
         : null;
 
     case "reserved":
@@ -92,30 +93,32 @@ export function availabilityString(book: AnyBook) {
 }
 
 function daysUntilLoanExpiry(expiryDateString) {
-    // Parse the expiry date and current date in millis
-    const expiryDateInMillis = new Date(expiryDateString).getTime();
-    const currentDateInMillis = new Date().getTime();
-    
-    // Calculate the difference
-    const differenceInMillis = expiryDateInMillis - currentDateInMillis;
-    
-    // Convert to days
-    const differenceInDays = Math.floor(differenceInMillis / (1000 * 60 * 60 * 24));
+  // Parse the expiry date and current date in millis
+  const expiryDateInMillis = new Date(expiryDateString).getTime();
+  const currentDateInMillis = new Date().getTime();
 
-    // If there is less than a day of time, show it in hours
-    if(differenceInDays < 1) {
-      const differenceInHours = Math.floor(differenceInMillis / (1000 * 60 * 60));
+  // Calculate the difference
+  const differenceInMillis = expiryDateInMillis - currentDateInMillis;
 
-      // if there is less than an hour of loan time, show it
-      if(differenceInHours < 1) {
-        return "less than an hour";
-      }
+  // Convert to days
+  const differenceInDays = Math.floor(
+    differenceInMillis / (1000 * 60 * 60 * 24)
+  );
 
-      // Return number of hours left
-      return `${differenceInHours} hours`;
+  // If there is less than a day of time, show it in hours
+  if (differenceInDays < 1) {
+    const differenceInHours = Math.floor(differenceInMillis / (1000 * 60 * 60));
+
+    // if there is less than an hour of loan time, show it
+    if (differenceInHours < 1) {
+      return "less than an hour";
     }
-    // Return number of days left
-    return `${differenceInDays} days`;
+
+    // Return number of hours left
+    return `${differenceInHours} hours`;
+  }
+  // Return number of days left
+  return `${differenceInDays} days`;
 }
 
 export function queueString(book: AnyBook) {

--- a/src/utils/book.tsx
+++ b/src/utils/book.tsx
@@ -42,26 +42,30 @@ export function getAuthorsString(book: AnyBook): string {
 
 export function availabilityString(book: AnyBook) {
   const status = book.status;
+  const availableCopies = book.copies?.available;
+  const totalCopies = book.copies?.total;
+  const queue =
+        typeof book.holds?.total === "number" ? book.holds.total : null;
 
   switch (status) {
     case "borrowable":
-    case "reservable":
-      const availableCopies = book.copies?.available;
-      const totalCopies = book.copies?.total;
-      const queue =
-        typeof book.holds?.total === "number" ? book.holds.total : null;
-
       return typeof availableCopies === "number" &&
         typeof totalCopies === "number"
+        ? `${availableCopies} out of ${totalCopies} copies available.`: null;
+    case "reservable":
+     return typeof availableCopies === "number" &&
+        typeof totalCopies === "number"
         ? `${availableCopies} out of ${totalCopies} copies available.${
-            queue ? ` ${queue} patrons in the queue.` : ""
-          }`
+            queue !== null ? ` ${queue} patrons in the queue.`: ""}`
         : null;
 
     case "reserved":
       const position = book.holds?.position;
+      const queueReserved =
+        typeof book.holds?.total === "number" ? book.holds.total : null;
+
       if (!position || isNaN(position)) return null;
-      return `${position} patrons ahead of you in the queue.`;
+      return `You are in position ${position} out of ${queueReserved} in the queue. ${availableCopies} out of ${totalCopies} copies available.`;
 
     case "on-hold":
       const until = book.availability?.until
@@ -74,17 +78,44 @@ export function availabilityString(book: AnyBook) {
       }.`;
 
     case "fulfillable":
-      const availableUntil = book.availability?.until
-        ? new Date(book.availability.until).toDateString()
+      const availableFor = book.availability?.until
+        ? daysUntilLoanExpiry(book.availability?.until)
         : "NaN";
 
-      return availableUntil !== "NaN"
-        ? `You have this book on loan until ${availableUntil}.`
+      return availableFor !== "NaN"
+        ? `You have this book on loan for ${availableFor}.`
         : null;
 
     case "unsupported":
       return null;
   }
+}
+
+function daysUntilLoanExpiry(expiryDateString) {
+    // Parse the expiry date and current date in millis
+    const expiryDateInMillis = new Date(expiryDateString).getTime();
+    const currentDateInMillis = new Date().getTime();
+    
+    // Calculate the difference
+    const differenceInMillis = expiryDateInMillis - currentDateInMillis;
+    
+    // Convert to days
+    const differenceInDays = Math.floor(differenceInMillis / (1000 * 60 * 60 * 24));
+
+    // If there is less than a day of time, show it in hours
+    if(differenceInDays < 1) {
+      const differenceInHours = Math.floor(differenceInMillis / (1000 * 60 * 60));
+
+      // if there is less than an hour of loan time, show it
+      if(differenceInHours < 1) {
+        return "less than an hour";
+      }
+
+      // Return number of hours left
+      return `${differenceInHours} hours`;
+    }
+    // Return number of days left
+    return `${differenceInDays} days`;
 }
 
 export function queueString(book: AnyBook) {


### PR DESCRIPTION
## Description

This pr makes more information visible to the user, regarding their loans and holds. This meant fixing some parsing, so that queue and copy information is extracted from all books, not only from books that have a borrow link.

JIRA: https://jira.it.helsinki.fi/browse/EKIRJASTO-649
## How Can This Be Tested?

This can be tested by loaning and putting books on hold
- Books on loan should show the remaining loan time in days/hours/less than an hour
- Books on hold should show the length of the queue and number of available and all copies
- Holdable books should show the length of current queue and number of available and all copies

I have:
- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
