### PR TITLE
Ekir 677 show return button for audiobooks

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -29,11 +29,10 @@ export const globalTypes = {
   companionApp: {
     name: "Companion App",
     description: "Companion App",
-    defaultValue: "simplye",
+    defaultValue: "E-kirjasto",
     toolbar: {
       items: [
-        { value: "simplye", title: "SimplyE" },
-        { value: "openebooks", title: "Open eBooks" }
+        { value: "E-kirjasto", title: "E-kirjasto" }
       ]
     }
   }

--- a/community-config.yml
+++ b/community-config.yml
@@ -48,7 +48,7 @@ media_support:
   application/vnd.readium.lcp.license.v1.0+json:
     application/pdf: show 
     application/epub+zip: show
-    application/audiobook+lcp: show
+    application/audiobook+lcp: redirect
     text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media": show
 
 # defines the companion app for the instance. Can be "simplye" or "openebooks"

--- a/community-config.yml
+++ b/community-config.yml
@@ -53,7 +53,7 @@ media_support:
 
 # defines the companion app for the instance. Can be "simplye" or "openebooks"
 # default is "simplye"
-companion_app: simplye
+companion_app: E-kirjasto
 
 # BUGSNAG: defines the bugsnag api key to integrate error tracking
 # bugsnag_api_key: xxx

--- a/src/auth/stories/login.stories.tsx
+++ b/src/auth/stories/login.stories.tsx
@@ -28,6 +28,6 @@ const Template: StoryFn = ({ children, ...rest }) => (
 export const Basic = Template.bind({});
 Basic.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   }
 };

--- a/src/components/BookStatus.tsx
+++ b/src/components/BookStatus.tsx
@@ -18,7 +18,7 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
     : false;
 
   const companionApp =
-    APP_CONFIG.companionApp === "openebooks" ? "Open eBooks" : "Palace";
+    APP_CONFIG.companionApp === "E-kirjasto" ? "in the E-kirjasto App" : "";
 
   const str =
     status === "borrowable"
@@ -30,7 +30,7 @@ const BookStatus: React.FC<{ book: AnyBook }> = ({ book }) => {
       : status === "on-hold"
       ? "Ready to Borrow"
       : status === "fulfillable"
-      ? `Ready to Read${redirectUser ? ` in ${companionApp}` : ""}!`
+      ? `Ready to Read${redirectUser ? ` ${companionApp}` : ""}!`
       : "Unsupported";
 
   return (

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -101,7 +101,7 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />
-      {APP_CONFIG.companionApp === "simplye" && <DownloadSimplyECallout />}
+      {APP_CONFIG.companionApp === "E-kirjasto" && <DownloadSimplyECallout />}
     </footer>
   );
 };

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -47,38 +47,7 @@ test("shows external links when present in state w/ apropriate attributes", () =
 });
 
 describe("toggling SimplyE Branding", () => {
-  test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
-    mockConfig({ companionApp: "openebooks" });
-
-    const utils = render(<Footer />);
-
-    expect(utils.queryByText(/download E-kirjasto/i)).not.toBeInTheDocument();
-
-    expect(
-      utils.queryByText(
-        "Our mobile app lets you browse, borrow and read from our whole collection of ebooks, audiobooks and magazines right on your phone!"
-      )
-    ).not.toBeInTheDocument();
-
-    // badges
-    const iosbadge = utils.queryByText(
-      /download E-kirjasto on the apple app store/i
-    );
-
-    expect(iosbadge).not.toBeInTheDocument();
-
-    const googleBadge = utils.queryByText(
-      /get E-kirjasto on the google play store/
-    );
-    expect(googleBadge).not.toBeInTheDocument();
-
-    // my books nav link
-    const myBooks = utils.queryByText(/my books/i);
-    expect(myBooks).toBeInTheDocument();
-    expect(myBooks).toHaveAttribute("href", "/testlib/loans");
-  });
-
-  test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
+  test("shows E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is 'E-kirjasto'", () => {
     mockConfig({ companionApp: "E-kirjasto" });
 
     const utils = render(<Footer />);

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -79,7 +79,7 @@ describe("toggling SimplyE Branding", () => {
   });
 
   test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", () => {
-    mockConfig({ companionApp: "simplye" });
+    mockConfig({ companionApp: "E-kirjasto" });
 
     const utils = render(<Footer />);
 

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -94,6 +94,7 @@ const AccessCard: React.FC<{
         id={book.id}
         text="Return"
       />
+      # In E-kirjasto, for now, this condition is never true
       {isFulfillable && redirectUser && (
         <Text variant="text.body.italic">
           If you would rather read on your computer, you can:

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -94,7 +94,6 @@ const AccessCard: React.FC<{
         id={book.id}
         text="Return"
       />
-      # In E-kirjasto, for now, this condition is never true
       {isFulfillable && redirectUser && (
         <Text variant="text.body.italic">
           If you would rather read on your computer, you can:

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -100,8 +100,8 @@ describe("book details page", () => {
     expect(screen.getByText("ePub")).toBeInTheDocument();
   });
 
-  test("does not show E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is ''", () => {
-    mockConfig({ companionApp: "" });
+  test("shows E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is ''", () => {
+    mockConfig({ companionApp: "E-kirjasto" });
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
 

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -100,8 +100,8 @@ describe("book details page", () => {
     expect(screen.getByText("ePub")).toBeInTheDocument();
   });
 
-  test("does not show simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'openebooks'", () => {
-    mockConfig({ companionApp: "openebooks" });
+  test("does not show E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is ''", () => {
+    mockConfig({ companionApp: "" });
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
 
@@ -115,8 +115,8 @@ describe("book details page", () => {
     ).not.toBeInTheDocument();*/
   });
 
-  test("shows simplyE callout when NEXT_PUBLIC_COMPANION_APP is 'simplye'", async () => {
-    mockConfig({ companionApp: "simplye" });
+  test("shows E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is 'E-kirjasto'", async () => {
+    mockConfig({ companionApp: "E-kirjasto" });
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
     expect(screen.getByText("Download E-kirjasto")).toBeInTheDocument();

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -430,22 +430,24 @@ describe("FulfillableBook", () => {
   });
   test("correct title and subtitle with companion app redirect", () => {
     mockConfig({
-      companionApp: "simplye"
+      companionApp: "E-kirjasto"
     });
     setup(<FulfillmentCard book={bookWithRedirect} />);
     expect(screen.queryByText("Ready to Read!")).not.toBeInTheDocument();
-    expect(screen.getByText("Ready to Read in Palace!")).toBeInTheDocument();
+    expect(
+      screen.getByText("Ready to Read in the E-kirjasto App!")
+    ).toBeInTheDocument();
     expect(
       screen.getByText("If you would rather read on your computer, you can:")
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Download EPUB" }));
   });
 
-  test("correct title and subtitle when COMPANION_APP is set to openebooks", () => {
-    mockConfig({ companionApp: "openebooks" });
+  test("correct title and subtitle when COMPANION_APP is set to E-kirjasto", () => {
+    mockConfig({ companionApp: "E-kirjasto" });
     setup(<FulfillmentCard book={bookWithRedirect} />);
     expect(
-      screen.getByText("Ready to Read in Open eBooks!")
+      screen.getByText("Ready to Read in the E-kirjasto App!")
     ).toBeInTheDocument();
   });
 

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -311,7 +311,7 @@ describe("reserved", () => {
 });
 
 describe("FulfillableBook", () => {
-  beforeEach(() => mockConfig({ companionApp: "simplye" }));
+  beforeEach(() => mockConfig({ companionApp: "E-kirjasto" }));
 
   const downloadableBook = mergeBook<FulfillableBook>({
     status: "fulfillable",

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -65,7 +65,7 @@ export const BookDetails: React.FC = () => {
           <div sx={{ flex: ["1 1 auto", 0.33], mr: [0, 4], mb: [3, 0] }}>
             <BookCover book={book} sx={{ maxWidth: [180, "initial"] }} />
 
-            {APP_CONFIG.companionApp === "simplye" && (
+            {APP_CONFIG.companionApp === "E-kirjasto" && (
               <SimplyECallout sx={{ display: ["none", "block"] }} />
             )}
           </div>

--- a/src/components/bookDetails/stories/page/BorrowableBook.stories.tsx
+++ b/src/components/bookDetails/stories/page/BorrowableBook.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn = args => <BookPage {...args} />;
 export const BorrowableBook = Template.bind({});
 BorrowableBook.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: borrowableBook
@@ -23,7 +23,7 @@ BorrowableBook.parameters = {
 export const WithAvailability = Template.bind({});
 WithAvailability.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {

--- a/src/components/bookDetails/stories/page/FulfillableBook/OnlyCompanionApp.stories.tsx
+++ b/src/components/bookDetails/stories/page/FulfillableBook/OnlyCompanionApp.stories.tsx
@@ -28,7 +28,7 @@ const redirectExternal = {
 export const Basic = Template.bind({});
 Basic.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {
@@ -41,7 +41,7 @@ Basic.parameters = {
 export const WithAvailability = Template.bind({});
 WithAvailability.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {

--- a/src/components/bookDetails/stories/page/FulfillableBook/PrefersCompanionApp.stories.tsx
+++ b/src/components/bookDetails/stories/page/FulfillableBook/PrefersCompanionApp.stories.tsx
@@ -51,7 +51,7 @@ const redirectPdf = {
 export const DownloadEpub = Template.bind({});
 DownloadEpub.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {
@@ -64,7 +64,7 @@ DownloadEpub.parameters = {
 export const WithAvailability = Template.bind({});
 WithAvailability.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {

--- a/src/components/bookDetails/stories/page/FulfillableBook/PrefersWebApp.stories.tsx
+++ b/src/components/bookDetails/stories/page/FulfillableBook/PrefersWebApp.stories.tsx
@@ -31,7 +31,7 @@ const Template: StoryFn = args => <BookPage {...args} />;
 export const DownloadEpub = Template.bind({});
 DownloadEpub.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: fulfillableBook
@@ -41,7 +41,7 @@ DownloadEpub.parameters = {
 export const WithAvailability = Template.bind({});
 WithAvailability.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: {

--- a/src/components/bookDetails/stories/page/OnHoldBook.stories.tsx
+++ b/src/components/bookDetails/stories/page/OnHoldBook.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn = args => <BookPage {...args} />;
 export const OnHoldBook = Template.bind({});
 OnHoldBook.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: onHoldBook

--- a/src/components/bookDetails/stories/page/ReservableBook.stories.tsx
+++ b/src/components/bookDetails/stories/page/ReservableBook.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn = args => <BookPage {...args} />;
 export const ReservableBook = Template.bind({});
 ReservableBook.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: reservableBook

--- a/src/components/bookDetails/stories/page/ReservedBook.stories.tsx
+++ b/src/components/bookDetails/stories/page/ReservedBook.stories.tsx
@@ -13,7 +13,7 @@ const Template: StoryFn = args => <BookPage {...args} />;
 export const ReservedBook = Template.bind({});
 ReservedBook.parameters = {
   config: {
-    companionApp: "openebooks"
+    companionApp: "E-kirjasto"
   },
   swr: {
     data: reservedBook

--- a/src/config/fetch-config.js
+++ b/src/config/fetch-config.js
@@ -99,7 +99,7 @@ async function parseConfig(raw) {
   const unparsed = YAML.parse(raw);
   // specifically set defaults for a couple values.
   const companionApp =
-    unparsed.companion_app === "openebooks" ? "openebooks" : "simplye";
+    unparsed.companion_app === "E-kirjasto" ? "E-kirjasto" : "E-kirjasto";
 
   const showMedium = unparsed.show_medium !== false;
 

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -306,7 +306,7 @@ describe("FulfillableBook", () => {
     const book = entryToBook(entry, "http://test-url.com") as FulfillableBook;
 
     expect(book.status).toBe("fulfillable");
-    expect(book.revokeUrl).toBe(null);
+    expect(book.revokeUrl).toBe("/revoke");
   });
 
   test("doesn't include revokeUrl for Adobe-only books", () => {
@@ -329,7 +329,7 @@ describe("FulfillableBook", () => {
     const book = entryToBook(entry, "http://test-url.com") as FulfillableBook;
 
     expect(book.status).toBe("fulfillable");
-    expect(book.revokeUrl).toBe(null);
+    expect(book.revokeUrl).toBe("/revoke");
   });
 
   test("does include revokeUrl for books fulfillable outside Adobe or AxisNow", () => {

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -180,28 +180,6 @@ function buildFulfillmentLink(feedUrl: string) {
   };
 }
 
-/**
- * A book cannot be returned (even with a revoke url) if:
- *  - It is locked in to Adobe ACS
- *  - It is an axisnow book
- *  - It comes from certain vendors
- *
- * We use a heuristic to determine when books can be returned. This may
- * need to be updated in the future.
- */
-function canReturnFulfillableBook(links: OPDSAcquisitionLink[]): boolean {
-  return !!links.map(parseFormat).find(link => {
-    // no AxisNow
-    if (link.contentType === OPDS1.AxisNowWebpubMediaType) return false;
-    // match if there is otherwise a direct link. These won't be present
-    // if the book has been locked in to Adobe ACS
-    if (!link.indirectionType) return true;
-    // match if it has a link to read online externally.
-    if (link.contentType === OPDS1.ExternalReaderMediaType) return true;
-    return false;
-  });
-}
-
 function findRevokeUrl(links: OPDSLink[]) {
   return links.find(link => link.rel === OPDS1.RevokeLinkRel)?.href ?? null;
 }
@@ -333,7 +311,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
       ...book,
       status: "fulfillable",
       fulfillmentLinks: allFulfillmentLinks,
-      revokeUrl: canReturnFulfillableBook(acquisitionLinks) ? revokeUrl : null
+      revokeUrl: revokeUrl
     };
   }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,7 +20,7 @@ export type AppConfig = {
   instanceName: string;
   mediaSupport: MediaSupportConfig;
   libraries: LibrariesConfig;
-  companionApp: "simplye" | "openebooks";
+  companionApp: "E-kirjasto";
   showMedium: boolean;
   gtmId: string | null;
   bugsnagApiKey: string | null;

--- a/src/test-utils/fixtures/config.ts
+++ b/src/test-utils/fixtures/config.ts
@@ -4,7 +4,7 @@ export const config: AppConfig = {
   instanceName: "Test Instance",
   gtmId: null,
   bugsnagApiKey: null,
-  companionApp: "simplye",
+  companionApp: "E-kirjasto",
   showMedium: true,
   openebooks: null,
   libraries: {


### PR DESCRIPTION
## Description

Enables and shows the Return button for all content types.

Audiobooks show a redirect text to read the book in the app.

Replaces `simplye` and `Palace` with `E-kirjasto` when
- the fulfillable book is an audiobook and can't be read in the browser.
- `simplye` appears anywhere in e.g. the footer.

## How Can This Be Tested?

Borrow an audiobook/epub/pdf. A Return button is visible and the revoke action works.
Audiobooks should show a redirect message and shouldn't be possible to download or read online.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
