### PR TITLE
Remove adobe encryption

### DIFF
--- a/community-config.yml
+++ b/community-config.yml
@@ -35,10 +35,6 @@ media_support:
   application/atom+xml;type=entry;profile=opds-catalog:
     text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media": show
 
-  # Adobe Encryption
-  application/vnd.adobe.adept+xml:
-    application/epub+zip: redirect-and-show
-
   # Bearer Token Exchange
   application/vnd.librarysimplified.bearer-token+json:
     application/pdf: show
@@ -51,8 +47,7 @@ media_support:
     application/audiobook+lcp: redirect
     text/html;profile="http://librarysimplified.org/terms/profiles/streaming-media": show
 
-# defines the companion app for the instance. Can be "simplye" or "openebooks"
-# default is "simplye"
+# defines the companion app for the instance.
 companion_app: E-kirjasto
 
 # BUGSNAG: defines the bugsnag api key to integrate error tracking


### PR DESCRIPTION
This will prevent it from showing as a viable format to read

## Description

Remove Adobe encryption as a viable format to read.

## How Can This Be Tested?

Katinka's tail and Hello Hello Colors have adobe encryption as well as LCP. After borrowing these books, you should not see the `Download Adobe EPUB` as a fulfillment type.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
