### PR TITLE
EKIR-624 Add links to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -76,11 +76,6 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
               Leave feedback
             </FooterExternalLink>
           </ListItem>
-        </FooterList>
-      </div>
-      <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
-        <H3 sx={{ mt: 0 }}>Librarians</H3>
-        <FooterList>
           {helpEmail && (
             <ListItem>
               <FooterExternalLink href={helpEmail.href}>
@@ -95,6 +90,11 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
               </FooterExternalLink>
             </ListItem>
           )}
+        </FooterList>
+      </div>
+      <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
+        <H3 sx={{ mt: 0 }}>Librarians</H3>
+        <FooterList>
           <ListItem>
             <FooterExternalLink href={undefined}>Statistics</FooterExternalLink>
           </ListItem>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -38,66 +38,49 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
       }}
       className={className}
     >
-      <div sx={{ flex: "0 0 auto", mt: 5, mr: 5 }}>
-        <H3 sx={{ mt: 0, maxWidth: "100%" }}>{title}</H3>
-        <FooterList>
-          {libraryWebsite && (
-            <ListItem>
-              <FooterExternalLink href={libraryWebsite.href}>
-                Library Homepage
-              </FooterExternalLink>
-            </ListItem>
-          )}
-          <ListItem>
-            <NavButton variant="link" href="/loans" color="ui.black">
-              My Books
-            </NavButton>
-          </ListItem>
-          <ListItem>
-            {registration && (
-              <FooterExternalLink href={registration.href}>
-                Need a library card?
-              </FooterExternalLink>
-            )}
-          </ListItem>
-          {privacyPolicy && (
-            <ListItem>
-              <FooterExternalLink href={privacyPolicy.href}>
-                Privacy
-              </FooterExternalLink>
-            </ListItem>
-          )}
-          {tos && (
-            <ListItem>
-              <FooterExternalLink href={tos.href}>
-                Terms of Use
-              </FooterExternalLink>
-            </ListItem>
-          )}
-          {about && (
-            <ListItem>
-              <FooterExternalLink href={about.href}>About</FooterExternalLink>
-            </ListItem>
-          )}
-        </FooterList>
-      </div>
       <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
         <H3 sx={{ mt: 0 }}>Patron Support</H3>
         <FooterList>
-          {helpEmail && (
-            <ListItem>
-              <FooterExternalLink href={helpEmail.href}>
-                Email Support
-              </FooterExternalLink>
-            </ListItem>
-          )}
-          {helpWebsite && (
-            <ListItem>
-              <FooterExternalLink href={helpWebsite.href}>
-                Help Website
-              </FooterExternalLink>
-            </ListItem>
-          )}
+          <ListItem>
+            <FooterExternalLink href={undefined}>
+              Leave feedback
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/e-library-accessibility-statement"}>
+              Accessibility Statement
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/privacy-policy-data-protection-statement-and-description-data-file"}>
+              Privacy Policy
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/e-library-terms-use"}>
+              User Agreement
+            </FooterExternalLink>
+          </ListItem>
+        </FooterList>
+      </div>
+      <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
+        <H3 sx={{ mt: 0 }}>Librarians</H3>
+        <FooterList>
+          <ListItem>
+            <FooterExternalLink href={undefined}>
+              Statistics
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink href={undefined}>
+              User manual
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink href={undefined}>
+              Statements
+            </FooterExternalLink>
+          </ListItem>
         </FooterList>
       </div>
       <div sx={{ flex: "1 1 0" }} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,7 +8,6 @@ import ExternalLink from "./ExternalLink";
 import useLibraryContext from "./context/LibraryContext";
 import List, { ListItem } from "./List";
 import { H3, Text } from "./Text";
-import { NavButton } from "./Button";
 import SvgPhone from "icons/Phone";
 import IosBadge from "./storeBadges/IosBadge";
 import GooglePlayBadge from "./storeBadges/GooglePlayBadge";
@@ -21,9 +20,7 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
     helpWebsite,
     privacyPolicy,
     tos,
-    about,
-    registration,
-    libraryWebsite
+    about
   } = library.libraryLinks;
   const title = library.catalogName;
 
@@ -38,6 +35,39 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
       }}
       className={className}
     >
+      <div sx={{ flex: "0 0 auto", mt: 5, mr: 5 }}>
+        <H3 sx={{ mt: 0, maxWidth: "100%" }}>{title}</H3>
+        <FooterList>
+          {privacyPolicy && (
+            <ListItem>
+              <FooterExternalLink href={privacyPolicy.href}>
+                Privacy Policy
+              </FooterExternalLink>
+            </ListItem>
+          )}
+          {tos && (
+            <ListItem>
+              <FooterExternalLink href={tos.href}>
+                Terms of Use
+              </FooterExternalLink>
+            </ListItem>
+          )}
+          {about && (
+            <ListItem>
+              <FooterExternalLink href={about.href}>About</FooterExternalLink>
+            </ListItem>
+          )}
+          <ListItem>
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/e-library-accessibility-statement"
+              }
+            >
+              Accessibility Statement
+            </FooterExternalLink>
+          </ListItem>
+        </FooterList>
+      </div>
       <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
         <H3 sx={{ mt: 0 }}>Patron Support</H3>
         <FooterList>
@@ -46,30 +76,27 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
               Leave feedback
             </FooterExternalLink>
           </ListItem>
-          <ListItem>
-            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/e-library-accessibility-statement"}>
-              Accessibility Statement
-            </FooterExternalLink>
-          </ListItem>
-          <ListItem>
-            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/privacy-policy-data-protection-statement-and-description-data-file"}>
-              Privacy Policy
-            </FooterExternalLink>
-          </ListItem>
-          <ListItem>
-            <FooterExternalLink href={"https://www.kansalliskirjasto.fi/en/e-library/e-library-terms-use"}>
-              User Agreement
-            </FooterExternalLink>
-          </ListItem>
         </FooterList>
       </div>
       <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
         <H3 sx={{ mt: 0 }}>Librarians</H3>
         <FooterList>
+          {helpEmail && (
+            <ListItem>
+              <FooterExternalLink href={helpEmail.href}>
+                Email Support
+              </FooterExternalLink>
+            </ListItem>
+          )}
+          {helpWebsite && (
+            <ListItem>
+              <FooterExternalLink href={helpWebsite.href}>
+                Help Website
+              </FooterExternalLink>
+            </ListItem>
+          )}
           <ListItem>
-            <FooterExternalLink href={undefined}>
-              Statistics
-            </FooterExternalLink>
+            <FooterExternalLink href={undefined}>Statistics</FooterExternalLink>
           </ListItem>
           <ListItem>
             <FooterExternalLink href={undefined}>
@@ -77,9 +104,7 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
             </FooterExternalLink>
           </ListItem>
           <ListItem>
-            <FooterExternalLink href={undefined}>
-              Statements
-            </FooterExternalLink>
+            <FooterExternalLink href={undefined}>Statements</FooterExternalLink>
           </ListItem>
         </FooterList>
       </div>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -32,18 +32,10 @@ test("shows external links when present in state w/ apropriate attributes", () =
     expect(lnk).toHaveAttribute("rel", "noopener noreferrer");
     expect(lnk).toHaveAttribute("target", "__blank");
   };
-  expectExternalLink("Library Homepage (Opens in a new tab)");
-  expectExternalLink("Need a library card? (Opens in a new tab)");
-  expectExternalLink("Email Support (Opens in a new tab)");
-  expectExternalLink("Help Website (Opens in a new tab)");
-  expectExternalLink("Privacy (Opens in a new tab)");
+
+  expectExternalLink("Privacy Policy (Opens in a new tab)");
   expectExternalLink("Terms of Use (Opens in a new tab)");
   expectExternalLink("About (Opens in a new tab)");
-
-  // my books nav link
-  const myBooks = utils.getByRole("link", { name: /my books/i });
-  expect(myBooks).toBeInTheDocument();
-  expect(myBooks).toHaveAttribute("href", "/testlib/loans");
 });
 
 describe("toggling SimplyE Branding", () => {
@@ -82,12 +74,5 @@ describe("toggling SimplyE Branding", () => {
       "href",
       "https://play.google.com/store/apps/details?id=fi.kansalliskirjasto.ekirjasto"
     );
-
-    // my books nav link
-    const myBooks = utils.getByRole("link", {
-      name: /my books/i
-    });
-    expect(myBooks).toBeInTheDocument();
-    expect(myBooks).toHaveAttribute("href", "/testlib/loans");
   });
 });

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -33,6 +33,8 @@ test("shows external links when present in state w/ apropriate attributes", () =
     expect(lnk).toHaveAttribute("target", "__blank");
   };
 
+  expectExternalLink("Email Support (Opens in a new tab)");
+  expectExternalLink("Help Website (Opens in a new tab)");
   expectExternalLink("Privacy Policy (Opens in a new tab)");
   expectExternalLink("Terms of Use (Opens in a new tab)");
   expectExternalLink("About (Opens in a new tab)");


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This pr adds new links, (or spots for them) in the footer of the page. 

All links under the library name and Patron support, apart from accessibility statement, are coming from the library configuration. The "Leave feedback" button is still empty and thus leads nowhere.

## How Can This Be Tested?

This can be tested by looking at the footer, and there should be three links under Librarians, feedback link under Patron Support (and possibly help links). Under the Library, there no longer should be a link to library website or my books, and instead, at least accessibility statement.

Note: Testing against local backend, if you don't have links defined in Library configuration, they will not show up.
- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
