### PR TITLE
EKIR-683 Seperate target audience and agegroup from categories

### DIFF
--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -102,9 +102,7 @@ export const BookDetails: React.FC = () => {
               />
               <DetailField
                 heading="Age range"
-                details={book.ageRange
-                  ?.map(range => `Ages ${range}`)
-                  .join(", ")}
+                details={book.ageRange?.join(", ")}
               />
               <DetailField heading="Book format" details={book.format} />
             </div>

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -96,6 +96,16 @@ export const BookDetails: React.FC = () => {
                 heading="Categories"
                 details={book.categories?.join(", ")}
               />
+              <DetailField
+                heading="Audience"
+                details={book.audience?.join(", ")}
+              />
+              <DetailField
+                heading="Age range"
+                details={book.ageRange
+                  ?.map(range => `Ages ${range}`)
+                  .join(", ")}
+              />
               <DetailField heading="Book format" details={book.format} />
             </div>
             <ReportProblem book={book} />

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -222,6 +222,21 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
 
   const categories = entry.categories
     .filter(category => !!category.label)
+    .filter(
+      category =>
+        category.scheme !== "http://schema.org/audience" &&
+        category.scheme !== "http://schema.org/typicalAgeRange"
+    )
+    .map(category => category.label);
+
+  const audience = entry.categories
+    .filter(category => !!category.label)
+    .filter(category => category.scheme === "http://schema.org/audience")
+    .map(category => category.label);
+
+  const ageRange = entry.categories
+    .filter(category => !!category.label)
+    .filter(category => category.scheme === "http://schema.org/typicalAgeRange")
     .map(category => category.label);
 
   const acquisitionLinks = entry.links.filter(isAcquisitionLink);
@@ -292,6 +307,8 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     publisher: entry.publisher,
     published: entry.issued && formatDate(entry.issued),
     categories: categories,
+    audience: audience,
+    ageRange: ageRange,
     providerName: providerName,
     language: entry.language,
     url: detailUrl,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -181,6 +181,8 @@ export type Book<Status = EmptyObject> = Readonly<
     publisher?: string;
     published?: string;
     categories?: string[];
+    audience?: string[];
+    ageRange?: string[];
     providerName?: string;
     language?: string;
     relatedUrl: string | null;


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
This pr separates Audience and Age group from other types of categories a book has and shows them separately on the books's page. If there is no audience or age group, the particular field is not shown.

[EKIRJASTO-683](https://jira.it.helsinki.fi/browse/EKIRJASTO-683)

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

There should be an audience listed for most, if not all books, and age range for some books, in the information part of the book description

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
