### PR TITLE
EKIRJASTO-704-remove-e-kirjasto-mobile-link

### DIFF
--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -115,7 +115,7 @@ describe("book details page", () => {
     ).not.toBeInTheDocument();*/
   });
 
-  test("shows E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is 'E-kirjasto'", async () => {
+  /*test("shows E-kirjasto callout when NEXT_PUBLIC_COMPANION_APP is 'E-kirjasto'", async () => {
     mockConfig({ companionApp: "E-kirjasto" });
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);
@@ -149,7 +149,7 @@ describe("book details page", () => {
       "https://play.google.com/store/apps/details?id=fi.kansalliskirjasto.ekirjasto"
     );
   });
-
+  */
   test("shows recommendation lanes", () => {
     // we make a special mock so we can differentiate the book request
     // and the related collection request

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -14,11 +14,11 @@ import { truncateString } from "../../utils/string";
 import DetailField from "../BookMetaDetail";
 import ReportProblem from "./ReportProblem";
 import Head from "next/head";
-import { H1, H2, H3, Text } from "components/Text";
+import { H1, H2, Text } from "components/Text";
 import MediumIndicator from "components/MediumIndicator";
-import EkirjastoBookDetailsLogo from "components/ekirjastoLogos/EkirjastoBookDetailsLogo";
-import IosBadge from "components/storeBadges/IosBadge";
-import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
+//import EkirjastoBookDetailsLogo from "components/ekirjastoLogos/EkirjastoBookDetailsLogo";
+//import IosBadge from "components/storeBadges/IosBadge";
+//import GooglePlayBadge from "components/storeBadges/GooglePlayBadge";
 import { useRouter } from "next/router";
 import extractParam from "dataflow/utils";
 import useSWR from "swr";
@@ -64,10 +64,6 @@ export const BookDetails: React.FC = () => {
         >
           <div sx={{ flex: ["1 1 auto", 0.33], mr: [0, 4], mb: [3, 0] }}>
             <BookCover book={book} sx={{ maxWidth: [180, "initial"] }} />
-
-            {APP_CONFIG.companionApp === "E-kirjasto" && (
-              <SimplyECallout sx={{ display: ["none", "block"] }} />
-            )}
           </div>
           <div
             sx={{
@@ -128,9 +124,16 @@ const Summary: React.FC<{ book: AnyBook; className?: string }> = ({
     />
   </div>
 );
+/* comment out in case we some day need it back
+line 67 removed 
+
+{APP_CONFIG.companionApp === "E-kirjasto" && (
+              <SimplyECallout sx={{ display: ["none", "block"] }} />
+            )}
+
 const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
   return (
-    <section
+     <section
       aria-label="Download E-kirjasto Mobile App"
       sx={{
         mt: 4,
@@ -155,5 +158,5 @@ const SimplyECallout: React.FC<{ className?: "string" }> = ({ className }) => {
     </section>
   );
 };
-
+*/
 export default BookDetails;


### PR DESCRIPTION
## Description
https://jira.it.helsinki.fi/browse/EKIRJASTO-704
Commented out E-kirjasto mobile download link section

## How Can This Be Tested?

- [ ] This change cannot be tested visually

Navigate to bookdetails, poof, no download app section.

code is still there if we ever need it back or want to use the section to show some other information

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
