### PR TITLE
EKIRJASTO-705-remove-cursive-font

### DIFF
--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -160,7 +160,7 @@ export const BookListItem: React.FC<{
               </Link>
             </H2>
             {book.subtitle && (
-              <Text variant="callouts.italic" aria-label="Subtitle">
+              <Text variant="callout" aria-label="Subtitle">
                 , {truncateString(book.subtitle, 50)}
               </Text>
             )}
@@ -191,7 +191,7 @@ const Description: React.FC<{ book: AnyBook; className?: string }> = ({
 }) => {
   return (
     <div className={className}>
-      <Text variant="text.body.italic">
+      <Text variant="text.body">
         {truncateString(stripHTML(book.summary ?? ""), 280)}
       </Text>
       <NavButton

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -72,7 +72,7 @@ export const Collection: React.FC<{
             justifyContent: "center"
           }}
         >
-          <Text variant="text.callouts.italic">This collection is empty.</Text>
+          <Text variant="text.callouts">This collection is empty.</Text>
         </div>
       )}
     </div>

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -85,8 +85,7 @@ const Search: React.FC<SearchProps> = ({ className, ...props }) => {
           borderBottomLeftRadius: 30,
           letterSpacing: 0.4,
           padding: 15,
-          fontSize: 16,
-          fontFamily: "Asap-Regular"
+          fontSize: 16
         }}
         {...props}
       />
@@ -100,7 +99,6 @@ const Search: React.FC<SearchProps> = ({ className, ...props }) => {
           letterSpacing: "0.4px",
           borderTopRightRadius: "30px",
           borderBottomRightRadius: "30px",
-          fontFamily: "Asap-Regular",
           padding: "15px, 30px, 15px, 30px",
           fontSize: "16px"
         }}

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -19,7 +19,7 @@ const styles = {
   variant: "text.body.regular",
   width: "100%",
   "&::placeholder": {
-    fontStyle: "italic",
+    fontStyle: "normal",
     color: "ui.gray.dark",
     fontSize: "-1"
   }

--- a/src/components/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`LinkButton renders correct element 1`] = `
 .emotion-0 {
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -71,7 +71,7 @@ exports[`NavButton renders correct element 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   color: var(--theme-ui-colors-ui-white);
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -140,7 +140,7 @@ exports[`NavButton renders correct element 1`] = `
 
 exports[`variants filled (default) 1`] = `
 .emotion-0 {
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;
@@ -206,7 +206,7 @@ exports[`variants filled (default) 1`] = `
 
 exports[`variants ghost 1`] = `
 .emotion-0 {
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 0.875rem;
   font-weight: 700;
   line-height: 1.5;
@@ -286,7 +286,7 @@ exports[`variants link 1`] = `
   -webkit-text-decoration: underline;
   text-decoration: underline;
   background-color: transparent;
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 1rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/Select.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Select.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`select matches snapshot 1`] = `
   padding-bottom: 4px;
   border: 1px solid #bdbdbd;
   border-radius: 2px;
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-size: 0.875rem;
   font-weight: 300;
   line-height: 1.5;

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -17,25 +17,25 @@ exports[`TextInput renders properly and passes styles through 1`] = `
 }
 
 .emotion-0::-webkit-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0::-moz-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0:-ms-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0::placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
@@ -63,25 +63,25 @@ exports[`type textarea renders properly and passes styles throug 1`] = `
 }
 
 .emotion-0::-webkit-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0::-moz-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0:-ms-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-0::placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }

--- a/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TextInput renders properly and passes styles through 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;
@@ -55,7 +55,7 @@ exports[`type textarea renders properly and passes styles throug 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`renders as expected 1`] = `
   padding-top: 4px;
   padding-bottom: 4px;
   font-size: 1rem;
-  font-family: Asap,sans-serif;
+  font-family: Asap,Arial;
   font-weight: 300;
   line-height: 1.5;
   width: 100%;

--- a/src/components/__tests__/__snapshots__/form.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/form.test.tsx.snap
@@ -33,25 +33,25 @@ exports[`renders as expected 1`] = `
 }
 
 .emotion-1::-webkit-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-1::-moz-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-1:-ms-input-placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }
 
 .emotion-1::placeholder {
-  font-style: italic;
+  font-style: normal;
   color: var(--theme-ui-colors-ui-gray-dark);
   font-size: 0.875rem;
 }

--- a/src/css-overrides.css
+++ b/src/css-overrides.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Asap:wght@300;400;500;700&display=swap');
 
 /* this is to fix a problem in NYPL Design System setting global svg styles */
 svg {

--- a/src/theme/styles.ts
+++ b/src/theme/styles.ts
@@ -13,8 +13,8 @@ const styles = {
     color: "ui.black"
   },
   fonts: {
-    body: "Asap,sans-serif",
-    heading: "Asap,sans-serif",
+    body: "Asap, Arial",
+    heading: "Asap, Arial",
     monospace: "Menlo, monospace"
   }
 };

--- a/src/theme/typography.ts
+++ b/src/theme/typography.ts
@@ -1,7 +1,7 @@
 const typography = {
   fonts: {
-    body: "Asap,sans-serif",
-    heading: "Asap,sans-serif",
+    body: "Asap,Arial",
+    heading: "Asap,Arial",
     monospace: "Menlo, monospace"
   },
   fontSizes: {


### PR DESCRIPTION
## Description

Removed odd cursive like font that appeared inside the search box and search results view
Fixed completely wrong font that appeared
Removed italic style
https://jira.it.helsinki.fi/browse/EKIRJASTO-705

## How Can This Be Tested?

Search box and search results font should now visually match global font


<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
