### PR TITLE
EKIRJASTO-702-build footer links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -15,13 +15,7 @@ import { APP_CONFIG } from "utils/env";
 
 const Footer: React.FC<{ className?: string }> = ({ className }) => {
   const library = useLibraryContext();
-  const {
-    helpEmail,
-    helpWebsite,
-    privacyPolicy,
-    tos,
-    about
-  } = library.libraryLinks;
+  const { privacyPolicy, tos, about } = library.libraryLinks;
   const title = library.catalogName;
 
   return (
@@ -72,39 +66,61 @@ const Footer: React.FC<{ className?: string }> = ({ className }) => {
         <H3 sx={{ mt: 0 }}>Patron Support</H3>
         <FooterList>
           <ListItem>
-            <FooterExternalLink href={undefined}>
-              Leave feedback
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/e-library-instructions"
+              }
+            >
+              Help Website
             </FooterExternalLink>
           </ListItem>
-          {helpEmail && (
-            <ListItem>
-              <FooterExternalLink href={helpEmail.href}>
-                Email Support
-              </FooterExternalLink>
-            </ListItem>
-          )}
-          {helpWebsite && (
-            <ListItem>
-              <FooterExternalLink href={helpWebsite.href}>
-                Help Website
-              </FooterExternalLink>
-            </ListItem>
-          )}
+          <ListItem>
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/e-library-faq"
+              }
+            >
+              Frequently Asked Questions
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/magazines-available-e-library"
+              }
+            >
+              Magazines in E-library
+            </FooterExternalLink>
+          </ListItem>
         </FooterList>
       </div>
       <div sx={{ flex: "0 0 auto", mt: 5, mr: [3, 5] }}>
-        <H3 sx={{ mt: 0 }}>Librarians</H3>
+        <H3 sx={{ mt: 0 }}>For Librarians</H3>
         <FooterList>
           <ListItem>
-            <FooterExternalLink href={undefined}>Statistics</FooterExternalLink>
-          </ListItem>
-          <ListItem>
-            <FooterExternalLink href={undefined}>
-              User manual
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/municipalities-participating-e-library"
+              }
+            >
+              Municipalities participating E-library
             </FooterExternalLink>
           </ListItem>
           <ListItem>
-            <FooterExternalLink href={undefined}>Statements</FooterExternalLink>
+            <FooterExternalLink
+              href={
+                "https://www.kansalliskirjasto.fi/en/e-library/e-library-collection-policy"
+              }
+            >
+              Collection Policy
+            </FooterExternalLink>
+          </ListItem>
+          <ListItem>
+            <FooterExternalLink
+              href={"https://www.kiwi.fi/spaces/ekirjasto/overview"}
+            >
+              More For Librarians
+            </FooterExternalLink>
           </ListItem>
         </FooterList>
       </div>

--- a/src/components/__tests__/Footer.test.tsx
+++ b/src/components/__tests__/Footer.test.tsx
@@ -33,8 +33,6 @@ test("shows external links when present in state w/ apropriate attributes", () =
     expect(lnk).toHaveAttribute("target", "__blank");
   };
 
-  expectExternalLink("Email Support (Opens in a new tab)");
-  expectExternalLink("Help Website (Opens in a new tab)");
   expectExternalLink("Privacy Policy (Opens in a new tab)");
   expectExternalLink("Terms of Use (Opens in a new tab)");
   expectExternalLink("About (Opens in a new tab)");


### PR DESCRIPTION
## Description

https://jira.it.helsinki.fi/browse/EKIRJASTO-702
All links put to place
no embed, natlib x-frame-options prevents them, so used links with target blank instead

## How Can This Be Tested?

- [ ] This change cannot be tested visually

Scroll down to footer, open links one-by-one and verify title match linked page

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
