### PR TITLE
EKIRJASTO-708 Login integration, part 1

### DIFF
--- a/src/auth/AuthenticationHandler.tsx
+++ b/src/auth/AuthenticationHandler.tsx
@@ -2,10 +2,12 @@ import React from "react";
 import BasicAuthHandler from "./BasicAuthHandler";
 import BasicTokenAuthHandler from "./BasicTokenAuthHandler";
 import CleverAuthHandler from "./CleverAuthHandler";
+import EkirjastoAuthHandler from "./EkirjastoAuthHandler";
 import SamlAuthHandler from "./SamlAuthHandler";
 import {
   ClientBasicMethod,
   ClientBasicTokenMethod,
+  ClientEkirjastoMethod,
   ClientSamlMethod
 } from "interfaces";
 import {
@@ -13,19 +15,25 @@ import {
   CleverAuthType,
   CleverAuthMethod,
   SamlAuthType,
-  BasicTokenAuthType
+  BasicTokenAuthType,
+  EkirjastoAuthType,
+  EkirjastoMethod
 } from "../types/opds1";
 import track from "../analytics/track";
 import ApplicationError from "../errors";
 
 type SupportedAuthTypes =
+  | typeof EkirjastoAuthType
   | typeof BasicAuthType
   | typeof BasicTokenAuthType
   | typeof SamlAuthType
   | typeof CleverAuthType;
 
 type SupportedAuthHandlerProps = {
-  [key in SupportedAuthTypes]: key extends typeof BasicAuthType
+  [key in SupportedAuthTypes]
+    : key extends typeof EkirjastoAuthType
+    ? EkirjastoMethod
+    : key extends typeof BasicAuthType
     ? ClientBasicMethod
     : key extends typeof BasicTokenAuthType
     ? ClientBasicTokenMethod
@@ -44,6 +52,7 @@ export const authHandlers: {
     method: SupportedAuthHandlerProps[key];
   }>;
 } = {
+  [EkirjastoAuthType]: EkirjastoAuthHandler,
   [BasicAuthType]: BasicAuthHandler,
   [BasicTokenAuthType]: BasicTokenAuthHandler,
   [SamlAuthType]: SamlAuthHandler,
@@ -62,7 +71,9 @@ const AuthenticationHandler: React.ComponentType<AuthHandlerWrapperProps> = ({
 }) => {
   const _AuthHandler = authHandlers[method.type];
 
-  if (method.type === BasicTokenAuthType && typeof method !== "string") {
+  if (method.type === EkirjastoAuthType && typeof method !== "string") {
+    return <_AuthHandler method={method as ClientEkirjastoMethod} />;
+  }if (method.type === BasicTokenAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicTokenMethod} />;
   } else if (method.type === BasicAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicMethod} />;

--- a/src/auth/AuthenticationHandler.tsx
+++ b/src/auth/AuthenticationHandler.tsx
@@ -30,8 +30,7 @@ type SupportedAuthTypes =
   | typeof CleverAuthType;
 
 type SupportedAuthHandlerProps = {
-  [key in SupportedAuthTypes]
-    : key extends typeof EkirjastoAuthType
+  [key in SupportedAuthTypes]: key extends typeof EkirjastoAuthType
     ? EkirjastoMethod
     : key extends typeof BasicAuthType
     ? ClientBasicMethod
@@ -73,7 +72,8 @@ const AuthenticationHandler: React.ComponentType<AuthHandlerWrapperProps> = ({
 
   if (method.type === EkirjastoAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientEkirjastoMethod} />;
-  }if (method.type === BasicTokenAuthType && typeof method !== "string") {
+  }
+  if (method.type === BasicTokenAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicTokenMethod} />;
   } else if (method.type === BasicAuthType && typeof method !== "string") {
     return <_AuthHandler method={method as ClientBasicMethod} />;

--- a/src/auth/EkirjastoAuthHandler.tsx
+++ b/src/auth/EkirjastoAuthHandler.tsx
@@ -25,17 +25,17 @@ const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
   )?.href;
 
   //Create link with redirect
-    const urlWithRedirect = `${authenticationStartHref}&redirect_uri=${encodeURIComponent(
-        authSuccessUrl
-      )}`;
+  const urlWithRedirect = `${authenticationStartHref}&redirect_uri=${encodeURIComponent(
+    authSuccessUrl
+  )}`;
 
-      // Start login
-      React.useEffect(() => {
-        if (!token && urlWithRedirect) {
-          window.location.href = urlWithRedirect;
-          console.log(urlWithRedirect)
-        }
-      }, [token, signOut, urlWithRedirect]);
+  // Start login
+  React.useEffect(() => {
+    if (!token && urlWithRedirect) {
+      window.location.href = urlWithRedirect;
+      console.log(urlWithRedirect);
+    }
+  }, [token, signOut, urlWithRedirect]);
 
   return (
     <Stack direction="column" sx={{ alignItems: "center" }}>

--- a/src/auth/EkirjastoAuthHandler.tsx
+++ b/src/auth/EkirjastoAuthHandler.tsx
@@ -1,0 +1,48 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from "theme-ui";
+import * as React from "react";
+import { ClientEkirjastoMethod } from "interfaces";
+import LoadingIndicator from "components/LoadingIndicator";
+import Stack from "components/Stack";
+import useUser from "components/context/UserContext";
+import useLoginRedirectUrl from "auth/useLoginRedirect";
+import { clientOnly } from "components/ClientOnly";
+
+/**
+ * The Ekirjasto Auth handler sends you off to an external website to complete
+ * auth.
+ */
+const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
+  method
+}) => {
+  const { token, signOut } = useUser();
+  const { authSuccessUrl } = useLoginRedirectUrl();
+
+  // Get link for strong authentication
+  const authenticationStartHref = method.links?.find(
+    link => link.rel === "tunnistus_start"
+  )?.href;
+
+  //Create link with redirect
+    const urlWithRedirect = `${authenticationStartHref}&redirect_uri=${encodeURIComponent(
+        authSuccessUrl
+      )}`;
+
+      // Start login
+      React.useEffect(() => {
+        if (!token && urlWithRedirect) {
+          window.location.href = urlWithRedirect;
+          console.log(urlWithRedirect)
+        }
+      }, [token, signOut, urlWithRedirect]);
+
+  return (
+    <Stack direction="column" sx={{ alignItems: "center" }}>
+      <LoadingIndicator />
+      Logging in with EkirjastoAuthentication...
+    </Stack>
+  );
+};
+
+export default clientOnly(EkirjastoAuthHandler);

--- a/src/auth/Login.tsx
+++ b/src/auth/Login.tsx
@@ -23,14 +23,15 @@ export default function Login(): React.ReactElement {
   // Automatically redirect user to first supported auth method
   // Unless there is ekirjasto authentication, then redirect to that
   React.useEffect(() => {
-    const ekirjastoAuth = supportedAuthMethods.find(
-      method => method.type === EKIRJASTO_AUTH_TYPE
-    );
-    if (ekirjastoAuth) {
-      initLogin(ekirjastoAuth.id);
-    }
     if (supportedAuthMethods.length > 0) {
-      initLogin(supportedAuthMethods[0].id);
+      const ekirjastoAuth = supportedAuthMethods.find(
+        method => method.type === EKIRJASTO_AUTH_TYPE
+      );
+      if (ekirjastoAuth) {
+        initLogin(ekirjastoAuth.id);
+      } else {
+        initLogin(supportedAuthMethods[0].id);
+      }
     }
   }, [supportedAuthMethods, initLogin]);
 

--- a/src/auth/Login.tsx
+++ b/src/auth/Login.tsx
@@ -23,9 +23,11 @@ export default function Login(): React.ReactElement {
   // Automatically redirect user to first supported auth method
   // Unless there is ekirjasto authentication, then redirect to that
   React.useEffect(() => {
-    const ekirjastoAuth = supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)
+    const ekirjastoAuth = supportedAuthMethods.find(
+      method => method.type === EKIRJASTO_AUTH_TYPE
+    );
     if (ekirjastoAuth) {
-      initLogin(ekirjastoAuth.id)
+      initLogin(ekirjastoAuth.id);
     }
     if (supportedAuthMethods.length > 0) {
       initLogin(supportedAuthMethods[0].id);

--- a/src/auth/Login.tsx
+++ b/src/auth/Login.tsx
@@ -8,6 +8,7 @@ import { Text } from "components/Text";
 import LoadingIndicator from "components/LoadingIndicator";
 import useLogin from "auth/useLogin";
 import { isSupportedAuthType } from "./AuthenticationHandler";
+import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 
 export default function Login(): React.ReactElement {
   const { initLogin } = useLogin();
@@ -20,7 +21,12 @@ export default function Login(): React.ReactElement {
   );
 
   // Automatically redirect user to first supported auth method
+  // Unless there is ekirjasto authentication, then redirect to that
   React.useEffect(() => {
+    const ekirjastoAuth = supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)
+    if (ekirjastoAuth) {
+      initLogin(ekirjastoAuth.id)
+    }
     if (supportedAuthMethods.length > 0) {
       initLogin(supportedAuthMethods[0].id);
     }

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -1,0 +1,27 @@
+import ApplicationError, { ServerError } from "errors";
+import fetchWithHeaders from "../dataflow/fetch";
+
+/**
+ * Fetch bearer (circulation) token for authenticating user
+ */
+export async function fetchEAuthToken(
+  url: string | undefined,
+  token: string | undefined
+) {
+  if (!url) {
+    throw new ApplicationError({
+      title: "Incomplete Authentication Info",
+      detail: "No URL or Token was provided for authentication"
+    });
+  }
+
+  const response = await fetchWithHeaders(url, `Bearer ${token}`, {}, "POST");
+  const json = await response.json();
+  console.log(json)
+
+  if (!response.ok) {
+    throw new ServerError(url, response.status, json);
+  }
+
+  return json;
+}

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -17,7 +17,6 @@ export async function fetchEAuthToken(
 
   const response = await fetchWithHeaders(url, `Bearer ${token}`, {}, "POST");
   const json = await response.json();
-  console.log(json);
 
   if (!response.ok) {
     throw new ServerError(url, response.status, json);

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -17,7 +17,7 @@ export async function fetchEAuthToken(
 
   const response = await fetchWithHeaders(url, `Bearer ${token}`, {}, "POST");
   const json = await response.json();
-  console.log(json)
+  console.log(json);
 
   if (!response.ok) {
     throw new ServerError(url, response.status, json);

--- a/src/auth/useLoginRedirect.tsx
+++ b/src/auth/useLoginRedirect.tsx
@@ -7,7 +7,7 @@ import { IS_SERVER } from "utils/env";
 /**
  * Extracts the redirect url stored in the browser url bar and returns
  * a version including the origin (fullSuccessUrl) or a version that is
- * just a path (successPath).
+ * just a path (successPath), or a path for special authentication handling (authSuccessUrl)
  */
 export default function useLoginRedirectUrl() {
   const { buildMultiLibraryLink } = useLinkUtils();
@@ -33,8 +33,14 @@ export default function useLoginRedirectUrl() {
     ? ""
     : `${window.location.origin}${successPath}`;
 
+  // get the url where we redirect after authentication
+  const authSuccessUrl = IS_SERVER
+    ? ""
+    : `${window.location.origin}/api/authsuccess`;
+
   return {
     fullSuccessUrl,
-    successPath
+    successPath,
+    authSuccessUrl
   };
 }

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -44,7 +44,7 @@ interface UserProviderProps {
  * those change it will cause a refetch.
  */
 export const UserProvider = ({ children }: UserProviderProps) => {
-  const { shelfUrl, slug, authMethods } = useLibraryContext()
+  const { shelfUrl, slug, authMethods } = useLibraryContext();
   const { credentials, setCredentials, clearCredentials } = useCredentials(
     slug,
     authMethods
@@ -100,7 +100,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
           }
           if (credentials?.methodType === EkirjastoAuthType) {
             // TODO: token refresh on 401
-             console.log("EKIRJASTO REFRESH")
+            console.log("EKIRJASTO REFRESH");
           }
         }
       },
@@ -108,7 +108,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       // however, BasicTokenAuthType methods are retried in onErrorRetry to get new token
       onError: err => {
         if (err instanceof ServerError && err?.info.status === 401) {
-          if (credentials?.methodType !== BasicTokenAuthType ) {
+          if (credentials?.methodType !== BasicTokenAuthType) {
             setError(err);
             clearCredentials();
           }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -91,12 +91,17 @@ export interface ClientBasicTokenMethod extends OPDS1.BasicTokenAuthMethod {
   id: string;
 }
 
+export interface ClientEkirjastoMethod extends OPDS1.EkirjastoMethod {
+  id: string;
+}
+
 // auth methods once they have been processed for the app
 export type AppAuthMethod =
   | ClientCleverMethod
   | ClientBasicMethod
   | ClientBasicTokenMethod
-  | ClientSamlMethod;
+  | ClientSamlMethod
+  | ClientEkirjastoMethod;
 
 export type Token = {
   basicToken: string | undefined;

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -1,0 +1,70 @@
+import { fetchEAuthToken } from 'auth/ekirjastoFetch';
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { serialize } from 'cookie';
+import { LibraryProvider } from 'components/context/LibraryContext';
+import { APP_CONFIG } from 'utils/env';
+import { buildLibraryData, fetchAuthDocument } from 'dataflow/getLibraryData';
+import { EKIRJASTO_AUTH_TYPE } from 'utils/constants';
+
+type ResponseData = {
+  message: string
+}
+ 
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ResponseData>
+) {
+  // Handle POST method to /api/authsuccess
+  if (req.method === 'POST') {
+    // Available in the result are result, token and exp (token expiration time)
+    const { result, token } = req.body;
+
+    //If the authentication was successful
+    if(result === "success") {
+        // Get authenticateHref from our AppConfigs so we find a suitable link for getting the authenticate link for ekirjasto
+      const authenticateHref = await fetchEkirjastoAuthenticationLink()
+
+      // Get circulation token
+      const { access_token } = await fetchEAuthToken(
+            authenticateHref,
+            token
+          );
+
+      // Set the circulation token as a cookie that can be read on the other page and stored
+      res.setHeader('Set-Cookie', serialize('access_token', access_token, { 
+      httpOnly: false,
+      path: '/'
+    }));
+
+    // Redirect to back to ekirjasto
+    res.writeHead(302, { Location: '/ekirjasto'});
+    res.end();
+    }
+    if(result === "failure") {
+      // TODO: handling of authentication failure
+      res.status(401).redirect('/ekirjasto')
+    }
+  } else {
+    // If any other request comes to this location, just redirect to ekirjasto
+  res.status(200).redirect('/ekirjasto')
+  }
+}
+
+async function fetchEkirjastoAuthenticationLink()
+: Promise<string | undefined> {
+  // Extract ekirjasto information
+  const library = APP_CONFIG.libraries.ekirjasto;
+  // If for some reason we don't find the authentication document, return early
+  if (!library?.authDocUrl) {
+    return;
+  }
+  // Get the authentication document links for circulation authentication
+  const authDoc = await fetchAuthDocument(library?.authDocUrl);
+  const libraryData = buildLibraryData(authDoc, library?.title);
+  const links = libraryData.authMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)?.links;
+  // Get the authentication link
+  const authenticateHref = links?.find(
+    link => link.rel === "authenticate"
+  )?.href;
+  return authenticateHref;
+}

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -24,12 +24,12 @@ export default async function handler(
       const authenticateHref = await fetchEkirjastoAuthenticationLink();
 
       // Get circulation token
-      const { access_token } = await fetchEAuthToken(authenticateHref, token);
+      const { accessToken } = await fetchEAuthToken(authenticateHref, token);
 
       // Set the circulation token as a cookie that can be read on the other page and stored
       res.setHeader(
         "Set-Cookie",
-        serialize("access_token", access_token, {
+        serialize("access_token", accessToken, {
           httpOnly: false,
           path: "/"
         })

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -24,7 +24,10 @@ export default async function handler(
       const authenticateHref = await fetchEkirjastoAuthenticationLink();
 
       // Get circulation token
-      const { accessToken } = await fetchEAuthToken(authenticateHref, token);
+      const { access_token: accessToken } = await fetchEAuthToken(
+        authenticateHref,
+        token
+      );
 
       // Set the circulation token as a cookie that can be read on the other page and stored
       res.setHeader(

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -1,57 +1,55 @@
-import { fetchEAuthToken } from 'auth/ekirjastoFetch';
-import type { NextApiRequest, NextApiResponse } from 'next'
-import { serialize } from 'cookie';
-import { LibraryProvider } from 'components/context/LibraryContext';
-import { APP_CONFIG } from 'utils/env';
-import { buildLibraryData, fetchAuthDocument } from 'dataflow/getLibraryData';
-import { EKIRJASTO_AUTH_TYPE } from 'utils/constants';
+import { fetchEAuthToken } from "auth/ekirjastoFetch";
+import type { NextApiRequest, NextApiResponse } from "next";
+import { serialize } from "cookie";
+import { APP_CONFIG } from "utils/env";
+import { buildLibraryData, fetchAuthDocument } from "dataflow/getLibraryData";
+import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 
 type ResponseData = {
-  message: string
-}
- 
+  message: string;
+};
+
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<ResponseData>
 ) {
   // Handle POST method to /api/authsuccess
-  if (req.method === 'POST') {
+  if (req.method === "POST") {
     // Available in the result are result, token and exp (token expiration time)
     const { result, token } = req.body;
 
     //If the authentication was successful
-    if(result === "success") {
-        // Get authenticateHref from our AppConfigs so we find a suitable link for getting the authenticate link for ekirjasto
-      const authenticateHref = await fetchEkirjastoAuthenticationLink()
+    if (result === "success") {
+      // Get authenticateHref from our AppConfigs so we find a suitable link for getting the authenticate link for ekirjasto
+      const authenticateHref = await fetchEkirjastoAuthenticationLink();
 
       // Get circulation token
-      const { access_token } = await fetchEAuthToken(
-            authenticateHref,
-            token
-          );
+      const { access_token } = await fetchEAuthToken(authenticateHref, token);
 
       // Set the circulation token as a cookie that can be read on the other page and stored
-      res.setHeader('Set-Cookie', serialize('access_token', access_token, { 
-      httpOnly: false,
-      path: '/'
-    }));
+      res.setHeader(
+        "Set-Cookie",
+        serialize("access_token", access_token, {
+          httpOnly: false,
+          path: "/"
+        })
+      );
 
-    // Redirect to back to ekirjasto
-    res.writeHead(302, { Location: '/ekirjasto'});
-    res.end();
+      // Redirect to back to ekirjasto
+      res.writeHead(302, { Location: "/ekirjasto" });
+      res.end();
     }
-    if(result === "failure") {
+    if (result === "failure") {
       // TODO: handling of authentication failure
-      res.status(401).redirect('/ekirjasto')
+      res.status(401).redirect("/ekirjasto");
     }
   } else {
     // If any other request comes to this location, just redirect to ekirjasto
-  res.status(200).redirect('/ekirjasto')
+    res.status(200).redirect("/ekirjasto");
   }
 }
 
-async function fetchEkirjastoAuthenticationLink()
-: Promise<string | undefined> {
+async function fetchEkirjastoAuthenticationLink(): Promise<string | undefined> {
   // Extract ekirjasto information
   const library = APP_CONFIG.libraries.ekirjasto;
   // If for some reason we don't find the authentication document, return early
@@ -61,10 +59,11 @@ async function fetchEkirjastoAuthenticationLink()
   // Get the authentication document links for circulation authentication
   const authDoc = await fetchAuthDocument(library?.authDocUrl);
   const libraryData = buildLibraryData(authDoc, library?.title);
-  const links = libraryData.authMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)?.links;
+  const links = libraryData.authMethods.find(
+    method => method.type === EKIRJASTO_AUTH_TYPE
+  )?.links;
   // Get the authentication link
-  const authenticateHref = links?.find(
-    link => link.rel === "authenticate"
-  )?.href;
+  const authenticateHref = links?.find(link => link.rel === "authenticate")
+    ?.href;
   return authenticateHref;
 }

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -215,8 +215,7 @@ export interface AuthMethod<T extends AnyAuthType, L extends Link = Link> {
 export interface ServerSamlMethod
   extends AuthMethod<typeof SamlAuthType, SamlIdp> {}
 
-export interface EkirjastoMethod
-  extends AuthMethod<typeof EkirjastoAuthType> {}
+export interface EkirjastoMethod extends AuthMethod<typeof EkirjastoAuthType> {}
 
 export interface CleverAuthMethod extends AuthMethod<typeof CleverAuthType> {}
 

--- a/src/types/opds1.ts
+++ b/src/types/opds1.ts
@@ -168,7 +168,18 @@ type AuthDocLinkRelations =
   | "terms-of-service"
   | "about"
   | "alternate"
-  | "authenticate";
+  | "authenticate"
+  | "ekirjasto_token"
+  | "magazine_service"
+  | "api"
+  | "tunnistus_start"
+  | "tunnistus_finish"
+  | "passkey_login_start"
+  | "passkey_login_finish"
+  | "relations"
+  | "invite"
+  | "passkey_register_start"
+  | "passkey_register_finish";
 
 export interface AuthDocumentLink extends Link {
   rel: AuthDocLinkRelations;
@@ -183,6 +194,7 @@ export const CleverAuthType =
 export const ImplicitGrantAuthType = "http://opds-spec.org/auth/oauth/implicit";
 export const PasswordCredentialsAuthType =
   "http://opds-spec.org/auth/oauth/password";
+export const EkirjastoAuthType = "http://e-kirjasto.fi/authtype/ekirjasto";
 
 export type AnyAuthType =
   | typeof BasicAuthType
@@ -190,7 +202,8 @@ export type AnyAuthType =
   | typeof SamlAuthType
   | typeof CleverAuthType
   | typeof ImplicitGrantAuthType
-  | typeof PasswordCredentialsAuthType;
+  | typeof PasswordCredentialsAuthType
+  | typeof EkirjastoAuthType;
 
 // https://drafts.opds.io/authentication-for-opds-1.0
 export interface AuthMethod<T extends AnyAuthType, L extends Link = Link> {
@@ -201,6 +214,9 @@ export interface AuthMethod<T extends AnyAuthType, L extends Link = Link> {
 }
 export interface ServerSamlMethod
   extends AuthMethod<typeof SamlAuthType, SamlIdp> {}
+
+export interface EkirjastoMethod
+  extends AuthMethod<typeof EkirjastoAuthType> {}
 
 export interface CleverAuthMethod extends AuthMethod<typeof CleverAuthType> {}
 
@@ -237,7 +253,8 @@ export type ServerAuthMethod =
   | CleverAuthMethod
   | BasicAuthMethod
   | BasicTokenAuthMethod
-  | ServerSamlMethod;
+  | ServerSamlMethod
+  | EkirjastoMethod;
 
 export interface Announcement {
   id: string;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,3 +7,5 @@ export const DEFAULT_AVAILABILITY = "available";
 export const LOGIN_REDIRECT_QUERY_PARAM = "nextUrl";
 export const LOGIN_ERROR_QUERY_PARAM = "loginError";
 export const SAML_LOGIN_QUERY_PARAM = "access_token";
+export const EKIRJASTO_TOKEN_PARAM = "access_token";
+export const EKIRJASTO_AUTH_TYPE = "http://e-kirjasto.fi/authtype/ekirjasto";


### PR DESCRIPTION
<!--- Describe your changes -->

Added a way to handle ekirjasto authentication.

It's still missing passkey authentication, 401 handling, and some error handling.
## How Can This Be Tested?

Press the login button, it should open straight into the authentication page.
Follow the login, and after success, it should redirect you into /ekirjasto. The button changes to logout button, and loaning and holding should go smoothly. 

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
