### PR TITLE
Refactor magazine URL retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,19 @@ The following environment variables can be set to further configure the applicat
 
 - Set `AXE_TEST=true` to run the application with `react-axe` enabled (only works when `NODE_ENV` is "development").
 - Set `ANALYZE=true` to generate bundle analysis files inside `.next/analyze` which will show bundle sizes for server and client, as well as composition.
+- Set `NEXT_PUBLIC_MAGAZINES_ENV` to choose which magazines environment to use. Allowed values are `production` and `playground`.
+  - `production` uses `https://<magazines-production-url>`.
+  - `playground` uses `https://<magazines-playground-url>`.
+  - If not set (or set to an invalid value), it falls back to `production` when `NODE_ENV=production`, otherwise `playground`.
+- Set `NEXT_PUBLIC_MAGAZINES_ORIGIN` to override the allowed origin used for magazine iframe communication. If not set, the origin is derived from the selected magazines base URL.
+
+Example `.env.local` setup:
+
+```
+NEXT_PUBLIC_MAGAZINES_ENV=playground
+# Optional: override iframe allowed origin
+# NEXT_PUBLIC_MAGAZINES_ORIGIN=https://<magazines-allowed-origin>
+```
 
 ## Manager, Registry, and Application Configurations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2"
 services:
   web-patron:
     container_name: web-patron
@@ -6,6 +5,7 @@ services:
     environment:
       CONFIG_FILE: /config/config.yml
       NODE_ENV: production
+      NEXT_PUBLIC_MAGAZINES_ENV: playground
     volumes:
       - ./config:/app/config
     ports:

--- a/src/config/magazines.ts
+++ b/src/config/magazines.ts
@@ -14,22 +14,30 @@ const MAGAZINE_API_URLS = {
   playground: "https://lehdet-testing.e-kirjasto.fi/feed/catalog"
 } as const;
 
+type MagazineEnvironment = keyof typeof MAGAZINE_READER_URLS;
+
+function getMagazineEnvironment(): MagazineEnvironment {
+  const magazinesEnv = process.env.NEXT_PUBLIC_MAGAZINES_ENV;
+
+  if (magazinesEnv === "production" || magazinesEnv === "playground") {
+    return magazinesEnv;
+  }
+
+  return process.env.NODE_ENV === "production" ? "production" : "playground";
+}
+
 /**
  * Get the magazine reader base URL based on environment
  */
 export function getMagazineReaderUrl(): string {
-  return process.env.NODE_ENV === "production"
-    ? MAGAZINE_READER_URLS.production
-    : MAGAZINE_READER_URLS.playground;
+  return MAGAZINE_READER_URLS[getMagazineEnvironment()];
 }
 
 /**
  * Get the magazine API URL based on environment
  */
 export function getMagazineApiUrl(): string {
-  return process.env.NODE_ENV === "production"
-    ? MAGAZINE_API_URLS.production
-    : MAGAZINE_API_URLS.playground;
+  return MAGAZINE_API_URLS[getMagazineEnvironment()];
 }
 
 /**


### PR DESCRIPTION
## Description

This pull request improves the way the application selects magazine API and reader URLs based on the environment. Instead of relying solely on `NODE_ENV`, it uses `NEXT_PUBLIC_MAGAZINES_ENV`.

Changes:

* Read `NEXT_PUBLIC_MAGAZINES_ENV` in `docker-compose.yml` to explicitly set the magazines environment (`production` or `playground`).
* Refactored `getMagazineReaderUrl` and `getMagazineApiUrl` in `src/config/magazines.ts` to use `NEXT_PUBLIC_MAGAZINES_ENV` variable if set, falling back to `NODE_ENV` as before. This makes it easier to test different environments without changing the overall app environment.

