### PR TITLE
Refactor magazine link visibility based on user authentication

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -113,22 +113,25 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
           {libraryWebsite.title ?? `${libraryName} Home`}
         </AnchorButton>
       )}
-      <NavButton
-        variant="ghost"
-        color="ui.black"
-        href="/magazines"
-        sx={{ mr: 1 }}
-      >
-        Magazines (logged in users)
-      </NavButton>
-      <NavButton
-        variant="ghost"
-        color="ui.black"
-        href="/magazines-preview"
-        sx={{ mr: 1 }}
-      >
-        Magazines (anonymous users)
-      </NavButton>
+      {isAuthenticated ? (
+        <NavButton
+          variant="ghost"
+          color="ui.black"
+          href="/magazines"
+          sx={{ mr: 1 }}
+        >
+          Magazines
+        </NavButton>
+      ) : (
+        <NavButton
+          variant="ghost"
+          color="ui.black"
+          href="/magazines-preview"
+          sx={{ mr: 1 }}
+        >
+          Magazines
+        </NavButton>
+      )}
       <NavButton
         variant="ghost"
         color="ui.black"

--- a/src/config/magazines.ts
+++ b/src/config/magazines.ts
@@ -44,8 +44,21 @@ export function getMagazineApiUrl(): string {
  * Get the allowed origin for magazine iframe communication
  */
 export function getMagazineAllowedOrigin(): string {
-  const baseUrl = getMagazineReaderUrl();
-  return process.env.NEXT_PUBLIC_MAGAZINES_ORIGIN || new URL(baseUrl).origin;
+  const overrideOrigin = process.env.NEXT_PUBLIC_MAGAZINES_ORIGIN;
+
+  if (overrideOrigin) {
+    try {
+      return new URL(overrideOrigin).origin;
+    } catch {
+      // Ignore invalid override and fall back to reader base URL origin.
+    }
+  }
+
+  try {
+    return new URL(getMagazineReaderUrl()).origin;
+  } catch {
+    return MAGAZINE_READER_URLS.production;
+  }
 }
 
 /**

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -7,7 +7,7 @@ import * as React from "react";
 import { NextPage, GetStaticProps, GetStaticPaths } from "next";
 import LayoutPage from "components/LayoutPage";
 import withAppProps, { AppProps } from "dataflow/withAppProps";
-// import useUser from "components/context/UserContext";
+import useUser from "components/context/UserContext";
 import useLogin from "auth/useLogin";
 import useLibraryContext from "components/context/LibraryContext";
 import {
@@ -20,8 +20,7 @@ import BreadcrumbBar from "components/BreadcrumbBar";
 
 const MagazinesFixedContent: React.FC = () => {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
-  const token = "MOCK_TOKEN";
-  // const { token } = useUser();
+  const { token } = useUser();
   const { initLogin } = useLogin();
   const { slug } = useLibraryContext();
 


### PR DESCRIPTION
## Description

This pull request updates how the Magazines section is handled for authenticated and anonymous users.

**User Authentication and Navigation:**

* The `HeaderLinks` component now conditionally displays the Magazines navigation button: authenticated users are linked to `/magazines`, while anonymous users are linked to `/magazines-preview`, both labeled simply as "Magazines".

**Configuration and Environment Handling:**

* The `getMagazineAllowedOrigin` function now robustly validates the `NEXT_PUBLIC_MAGAZINES_ORIGIN` environment variable, falling back to default origins if the variable is invalid or missing.
**User Context and Token Handling:**

* The magazines index page (`[library]/magazines/index.tsx`) re-enables the use of the `useUser` hook to retrieve the actual user token, replacing the previous mock token implementation. 

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [X] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [X] Tested with Chrome
- [ ] Tested with Edge
- [X] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
