### PR TITLE
EKIR-754 Handle opening of magazines

### DIFF
--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -8,16 +8,43 @@ export async function fetchEAuthToken(
   url: string | undefined,
   token: string | undefined
 ) {
-  if (!url) {
+  if (!url || !token) {
     throw new ApplicationError({
       title: "Incomplete Authentication Info",
       detail: "No URL or Token was provided for authentication"
     });
   }
 
+  //If in some case, the bearer text is present, remove it so there is no repetition in the request
+  if (token?.startsWith("Bearer ")) {
+    token = token.replace("Bearer ", "")
+    console.log(token)
+  }
+
   const response = await fetchWithHeaders(url, `Bearer ${token}`, {}, "POST");
   const json = await response.json();
 
+  if (!response.ok) {
+    throw new ServerError(url, response.status, json);
+  }
+
+  return json;
+}
+
+export async function fetchEkirjastoToken(
+  url: string | undefined,
+  token: string | undefined
+) {
+  if (!url || !token) {
+    throw new ApplicationError({
+      title: "Incomplete Authentication Info",
+      detail: "No URL or Token was provided for authentication"
+    });
+  }
+
+  const response = await fetchWithHeaders(url, token, {}, "GET");
+  const json = await response.json();
+  
   if (!response.ok) {
     throw new ServerError(url, response.status, json);
   }

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -17,8 +17,7 @@ export async function fetchEAuthToken(
 
   //If in some case, the bearer text is present, remove it so there is no repetition in the request
   if (token?.startsWith("Bearer ")) {
-    token = token.replace("Bearer ", "")
-    console.log(token)
+    token = token.replace("Bearer ", "");
   }
 
   const response = await fetchWithHeaders(url, `Bearer ${token}`, {}, "POST");
@@ -44,7 +43,7 @@ export async function fetchEkirjastoToken(
 
   const response = await fetchWithHeaders(url, token, {}, "GET");
   const json = await response.json();
-  
+
   if (!response.ok) {
     throw new ServerError(url, response.status, json);
   }

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -113,6 +113,10 @@ function getCredentialsCookie(
   if (librarySlug === "ekirjasto") {
     // Get access token, for ekirjasto login credentials
     const accessToken = Cookie.get(cookieNameEkirjasto());
+    if(!accessToken) {
+      console.log("No access token")
+      return undefined
+    }
     // Create ekirjasto authentication credentials
     const authCredentials: AuthCredentials = {
       token: `Bearer ${accessToken}`,

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -113,9 +113,9 @@ function getCredentialsCookie(
   if (librarySlug === "ekirjasto") {
     // Get access token, for ekirjasto login credentials
     const accessToken = Cookie.get(cookieNameEkirjasto());
-    if(!accessToken) {
-      console.log("No access token")
-      return undefined
+    if (!accessToken) {
+      console.log("No access token");
+      return undefined;
     }
     // Create ekirjasto authentication credentials
     const authCredentials: AuthCredentials = {

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -3,7 +3,7 @@ import useCredentials from "auth/useCredentials";
 import useLibraryContext from "components/context/LibraryContext";
 import { fetchCollection } from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { AppAuthMethod, AnyBook, AuthCredentials, Token, ClientEkirjastoMethod } from "interfaces";
+import { AppAuthMethod, AnyBook, AuthCredentials, Token } from "interfaces";
 import * as React from "react";
 import useSWR from "swr";
 import { BasicTokenAuthType, EkirjastoAuthType } from "types/opds1";

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -121,13 +121,16 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       }
     }
   );
-  
+
   async function getEkirjastoToken(
     token: string,
     fetchUrl: string | undefined
-  ) : Promise<string> {
-    const { token : ekirjastoToken} = await fetchEkirjastoToken(fetchUrl, token)
-    return ekirjastoToken
+  ): Promise<string> {
+    const { token: ekirjastoToken } = await fetchEkirjastoToken(
+      fetchUrl,
+      token
+    );
+    return ekirjastoToken;
   }
 
   function signIn(

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -3,11 +3,12 @@ import useCredentials from "auth/useCredentials";
 import useLibraryContext from "components/context/LibraryContext";
 import { fetchCollection } from "dataflow/opds1/fetch";
 import { ServerError } from "errors";
-import { AppAuthMethod, AnyBook, AuthCredentials, Token } from "interfaces";
+import { AppAuthMethod, AnyBook, AuthCredentials, Token, ClientEkirjastoMethod } from "interfaces";
 import * as React from "react";
 import useSWR from "swr";
 import { BasicTokenAuthType, EkirjastoAuthType } from "types/opds1";
 import { addHours, isBefore } from "date-fns";
+import { fetchEkirjastoToken } from "auth/ekirjastoFetch";
 
 type Status = "authenticated" | "loading" | "unauthenticated";
 export type UserState = {
@@ -22,6 +23,10 @@ export type UserState = {
     authenticationUrl: string | undefined
   ) => void;
   signOut: () => void;
+  getEkirjastoToken: (
+    token: string,
+    fetchUrl: string | undefined
+  ) => Promise<string>;
   setBook: (book: AnyBook, id?: string) => void;
   error: any;
   token: string | undefined;
@@ -116,6 +121,14 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       }
     }
   );
+  
+  async function getEkirjastoToken(
+    token: string,
+    fetchUrl: string | undefined
+  ) : Promise<string> {
+    const { token : ekirjastoToken} = await fetchEkirjastoToken(fetchUrl, token)
+    return ekirjastoToken
+  }
 
   function signIn(
     token: string | Token,
@@ -160,6 +173,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     refetchLoans: mutate,
     signIn,
     signOut,
+    getEkirjastoToken,
     setBook,
     error,
     token: stringifyToken(credentials),

--- a/src/config/magazines.ts
+++ b/src/config/magazines.ts
@@ -73,5 +73,5 @@ export const MAGAZINE_CONFIG = {
 
   // Default iframe sandbox permissions
   IFRAME_SANDBOX:
-    "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox"
+    "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
 } as const;

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -10,7 +10,6 @@ import withAppProps, { AppProps } from "dataflow/withAppProps";
 import useUser from "components/context/UserContext";
 import useLogin from "auth/useLogin";
 import useLibraryContext from "components/context/LibraryContext";
-import useCredentials from "auth/useCredentials";
 import {
   getMagazineReaderUrl,
   getMagazineAllowedOrigin,
@@ -18,32 +17,31 @@ import {
 } from "config/magazines";
 import Head from "next/head";
 import BreadcrumbBar from "components/BreadcrumbBar";
-import { EkirjastoAuthType } from "types/opds1";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 
 const MagazinesFixedContent: React.FC = () => {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
-  const { token, signIn, getEkirjastoToken } = useUser();
+  const { token, getEkirjastoToken } = useUser();
   const { initLogin } = useLogin();
   const { slug, authMethods } = useLibraryContext();
-  const { credentials, setCredentials, clearCredentials } = useCredentials(
-      slug,
-      authMethods
-    );
-  const ekirMethod = authMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)
-  let ekirjastoToken: string | undefined
+  const ekirMethod = authMethods.find(
+    method => method.type === EKIRJASTO_AUTH_TYPE
+  );
+  let ekirjastoToken: string | undefined;
   if (ekirMethod && token) {
     try {
-    //Get the ekirjastoToken
-    const ekirjastoTokenUrl = ekirMethod.links.find(link => link.rel === "ekirjasto_token")?.href
-    ekirjastoToken = getEkirjastoToken(token, ekirjastoTokenUrl)
+      //Get the ekirjastoToken
+      const ekirjastoTokenUrl = ekirMethod.links.find(
+        link => link.rel === "ekirjasto_token"
+      )?.href;
+      ekirjastoToken = getEkirjastoToken(token, ekirjastoTokenUrl);
     } catch (error) {
       //Can not start the reader so should show not logged in or something
     }
   }
   if (!token) {
-    console.log("There is no token so should be logged out")
-    ekirjastoToken = undefined
+    console.log("There is no token so should be logged out");
+    ekirjastoToken = undefined;
   }
 
   const storageKey = React.useMemo(
@@ -69,10 +67,9 @@ const MagazinesFixedContent: React.FC = () => {
       const allowedOrigin = getMagazineAllowedOrigin();
 
       if (!token) {
-        console.log("No token!")
-        
+        console.log("No token!");
       }
-      
+
       if (e.origin !== allowedOrigin || typeof e.data !== "string") return;
 
       if (e.data === "ewl:unauthorized") {
@@ -100,7 +97,7 @@ const MagazinesFixedContent: React.FC = () => {
         });
       }
     },
-    [initLogin, ekirjastoToken, storageKey]
+    [initLogin, ekirjastoToken, token, storageKey]
   );
 
   React.useEffect(() => {

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -10,6 +10,7 @@ import withAppProps, { AppProps } from "dataflow/withAppProps";
 import useUser from "components/context/UserContext";
 import useLogin from "auth/useLogin";
 import useLibraryContext from "components/context/LibraryContext";
+import useCredentials from "auth/useCredentials";
 import {
   getMagazineReaderUrl,
   getMagazineAllowedOrigin,
@@ -17,12 +18,33 @@ import {
 } from "config/magazines";
 import Head from "next/head";
 import BreadcrumbBar from "components/BreadcrumbBar";
+import { EkirjastoAuthType } from "types/opds1";
+import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 
 const MagazinesFixedContent: React.FC = () => {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
-  const { token } = useUser();
+  const { token, signIn, getEkirjastoToken } = useUser();
   const { initLogin } = useLogin();
-  const { slug } = useLibraryContext();
+  const { slug, authMethods } = useLibraryContext();
+  const { credentials, setCredentials, clearCredentials } = useCredentials(
+      slug,
+      authMethods
+    );
+  const ekirMethod = authMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)
+  let ekirjastoToken: string | undefined
+  if (ekirMethod && token) {
+    try {
+    //Get the ekirjastoToken
+    const ekirjastoTokenUrl = ekirMethod.links.find(link => link.rel === "ekirjasto_token")?.href
+    ekirjastoToken = getEkirjastoToken(token, ekirjastoTokenUrl)
+    } catch (error) {
+      //Can not start the reader so should show not logged in or something
+    }
+  }
+  if (!token) {
+    console.log("There is no token so should be logged out")
+    ekirjastoToken = undefined
+  }
 
   const storageKey = React.useMemo(
     () => `${MAGAZINE_CONFIG.STORAGE_KEY_PREFIX}${slug ?? "default"}`,
@@ -45,12 +67,18 @@ const MagazinesFixedContent: React.FC = () => {
   const handleMessage = React.useCallback(
     (e: MessageEvent) => {
       const allowedOrigin = getMagazineAllowedOrigin();
+
+      if (!token) {
+        console.log("No token!")
+        
+      }
+      
       if (e.origin !== allowedOrigin || typeof e.data !== "string") return;
 
       if (e.data === "ewl:unauthorized") {
-        if (token) {
+        if (ekirjastoToken) {
           iframeRef.current?.contentWindow?.postMessage(
-            `ewl:login:${token}`,
+            `ewl:login:${ekirjastoToken}`,
             allowedOrigin
           );
         } else {
@@ -72,7 +100,7 @@ const MagazinesFixedContent: React.FC = () => {
         });
       }
     },
-    [initLogin, token, storageKey]
+    [initLogin, ekirjastoToken, storageKey]
   );
 
   React.useEffect(() => {


### PR DESCRIPTION
## Description

This pr adds the fetching and handling of the ekirjasto token for the magazines.

This does not handle 401 answers or logout, and thus it is possible to get logged of the account from the backend while still being able to read magazines.

Jira: [EKIRJASTO-753](https://jira.it.helsinki.fi/browse/EKIRJASTO-753)

## How Can This Be Tested?
Can be tested by logging in and then going to magazines page. The magazines page should open, and be readable.

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
