### PR TITLE
EKIRJASTO-755 Remove Coveralls step from test-and-build workflow

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -128,11 +128,6 @@ jobs:
       - name: Test
         run: npm run test:ci -- --coverage
 
-      - name: Coveralls Report
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
   publish:
     name: Publish image to Docker registry
     needs: [lint, typecheck, test]


### PR DESCRIPTION
## Description

- This pull request removes the Coveralls test coverage/statistics step from test-and-build workflow
  - test coverage is also monitored using other tools, and the unreliability of the service could slow down our web development
- [EKIRJASTO-755 ](https://jira.it.helsinki.fi/browse/EKIRJASTO-755)

## How Can This Be Tested?

- Check that the actions and tests pass

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
