### PR TITLE
Update iframe sandbox permissions for Safari compatibility

### DIFF
--- a/src/config/magazines.ts
+++ b/src/config/magazines.ts
@@ -71,7 +71,8 @@ export const MAGAZINE_CONFIG = {
   // Default iframe permissions
   IFRAME_ALLOW: "fullscreen; clipboard-read; clipboard-write",
 
-  // Default iframe sandbox permissions
+  // The embedded reader needs to redirect the host page in Safari/WebKit.
+  // `allow-top-navigation-by-user-activation` is not sufficient there.
   IFRAME_SANDBOX:
-    "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation-by-user-activation"
+    "allow-scripts allow-same-origin allow-forms allow-popups allow-popups-to-escape-sandbox allow-top-navigation"
 } as const;


### PR DESCRIPTION
## Description

This updates the iframe sandbox permissions in the `MAGAZINE_CONFIG` to improve compatibility with Safari/WebKit browsers. The key change is replacing `allow-top-navigation-by-user-activation` with `allow-top-navigation` to ensure embedded readers can redirect the host page as needed.

Iframe sandbox permissions update:

* Changed the `IFRAME_SANDBOX` value in `magazines.ts` 

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
