### PR TITLE
EKIRJASTO-708 Fix 401 refresh

### DIFF
--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -121,7 +121,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
             }
             if (credentials?.methodType === EkirjastoAuthType) {
               try {
-                console.log("EKIRJREFRESH");
                 // Try refreshing the access token
                 const { access_token: accessToken } = await fetchEAuthToken(
                   credentials?.authenticationUrl,

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -84,10 +84,10 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         : null,
       fetchLoans,
       {
-        shouldRetryOnError: credentials?.methodType === BasicTokenAuthType,
+        shouldRetryOnError: credentials?.methodType === BasicTokenAuthType || credentials?.methodType === EkirjastoAuthType,
         revalidateOnFocus: shouldRevalidate(),
         revalidateOnReconnect: false,
-        errorRetryCount: credentials?.methodType === BasicTokenAuthType ? 1 : 0,
+        errorRetryCount: credentials?.methodType === BasicTokenAuthType || credentials?.methodType === EkirjastoAuthType ? 1 : 0,
         // Try and fetch new token once old token has expired
         onErrorRetry: async (err, _key, _config, revalidate) => {
           if (err instanceof ServerError && err?.info.status === 401) {
@@ -115,6 +115,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
             }
             if (credentials?.methodType === EkirjastoAuthType) {
               try {
+                console.log("EKIRJREFRESH")
                 // Try refreshing the access token
                 const { access_token: accessToken } = await fetchEAuthToken(
                   credentials?.authenticationUrl,

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -84,10 +84,16 @@ export const UserProvider = ({ children }: UserProviderProps) => {
         : null,
       fetchLoans,
       {
-        shouldRetryOnError: credentials?.methodType === BasicTokenAuthType || credentials?.methodType === EkirjastoAuthType,
+        shouldRetryOnError:
+          credentials?.methodType === BasicTokenAuthType ||
+          credentials?.methodType === EkirjastoAuthType,
         revalidateOnFocus: shouldRevalidate(),
         revalidateOnReconnect: false,
-        errorRetryCount: credentials?.methodType === BasicTokenAuthType || credentials?.methodType === EkirjastoAuthType ? 1 : 0,
+        errorRetryCount:
+          credentials?.methodType === BasicTokenAuthType ||
+          credentials?.methodType === EkirjastoAuthType
+            ? 1
+            : 0,
         // Try and fetch new token once old token has expired
         onErrorRetry: async (err, _key, _config, revalidate) => {
           if (err instanceof ServerError && err?.info.status === 401) {
@@ -115,7 +121,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
             }
             if (credentials?.methodType === EkirjastoAuthType) {
               try {
-                console.log("EKIRJREFRESH")
+                console.log("EKIRJREFRESH");
                 // Try refreshing the access token
                 const { access_token: accessToken } = await fetchEAuthToken(
                   credentials?.authenticationUrl,


### PR DESCRIPTION
## Description

A fix to 401 refresh pr, that had some information removed while fixing a merge conflict, causing the code to not work correctly, meaning sometimes logging in did not work, and the refresh would not work.


## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
