### PR TITLE
EKIR-708 Logout temporary fix

### DIFF
--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -199,7 +199,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
       sameSite: "None",
       secure: true
     });
-    logoutEkirjastoUser(logoutUrl)
+    logoutEkirjastoUser(logoutUrl);
     signOut();
   }
 

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -14,7 +14,7 @@ import {
   logoutEkirjastoUser
 } from "auth/ekirjastoFetch";
 import Cookie from "js-cookie";
-import { LODOUT_COOKIE_PARAM, EKIRJASTO_DOMAIN } from "utils/constants";
+import { LOGOUT_COOKIE_PARAM, EKIRJASTO_DOMAIN } from "utils/constants";
 
 type Status = "authenticated" | "loading" | "unauthenticated";
 export type UserState = {
@@ -193,18 +193,14 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     logoutUrl: string
   ) {
     const ekirjastoToken = getEkirjastoToken(token, logoutTokenUrl);
-    Cookie.set(LODOUT_COOKIE_PARAM, ekirjastoToken, {
+    Cookie.set(LOGOUT_COOKIE_PARAM, ekirjastoToken, {
       path: "/",
       domain: EKIRJASTO_DOMAIN,
       sameSite: "None",
       secure: true
     });
-    logoutEkirjastoUser(logoutUrl).then(response => {
-      if (response.status === 200) {
-        // Perform local logout actions only if logout was succesful on server
-        signOut();
-      }
-    });
+    logoutEkirjastoUser(logoutUrl)
+    signOut();
   }
 
   function signOut() {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -9,5 +9,5 @@ export const LOGIN_ERROR_QUERY_PARAM = "loginError";
 export const SAML_LOGIN_QUERY_PARAM = "access_token";
 export const EKIRJASTO_TOKEN_PARAM = "access_token";
 export const EKIRJASTO_AUTH_TYPE = "http://e-kirjasto.fi/authtype/ekirjasto";
-export const LODOUT_COOKIE_PARAM = "SESSION";
+export const LOGOUT_COOKIE_PARAM = "SESSION";
 export const EKIRJASTO_DOMAIN = ".e-kirjasto.fi";


### PR DESCRIPTION
## Description

Currently in test, we can not log out, since the last code didn't work. This pr enables logging out, while we implement the working solution.

## How Can This Be Tested?

- [x] This change cannot be tested visually

This should work as previously when tested locally, but the logout happens in test despite the get request failing.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
