### PR TITLE
EKIRJASTO-708 Handle logout with redirect

### DIFF
--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -7,20 +7,27 @@ import ExternalLink from "components/ExternalLink";
 import { Text } from "components/Text";
 import LoadingIndicator from "components/LoadingIndicator";
 import { isSupportedAuthType } from "./AuthenticationHandler";
-import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
+import {
+  EKIRJASTO_AUTH_TYPE,
+  EKIRJASTO_DOMAIN,
+  LOGOUT_COOKIE_PARAM
+} from "utils/constants";
 import useUser from "components/context/UserContext";
-import Cookie from "js-cookie";
 import { useEffect, useState } from "react";
+import useLoginRedirectUrl from "./useLoginRedirect";
 
 export default function Logout(): React.ReactElement {
+  const { token, signOut, getEkirjastoToken } = useUser();
+  const { logoutRedirectUrl } = useLoginRedirectUrl();
+  const { authMethods } = useLibraryContext();
+
+  const [ekirjastoToken, setEkirjastoToken] = useState("");
+
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
-  const { authMethods } = useLibraryContext();
   const supportedAuthMethods = authMethods.filter(m =>
     isSupportedAuthType(m.type)
   );
-
-  const { token, signOut, getEkirjastoToken } = useUser();
 
   const method = supportedAuthMethods.find(
     method => method.type === EKIRJASTO_AUTH_TYPE
@@ -35,7 +42,10 @@ export default function Logout(): React.ReactElement {
     link => link.rel === "logout"
   )?.href;
 
-  const [ekirjastoToken, setEkirjastoToken] = useState("");
+  // Add the redirect link
+  const urlWithRedirect = `${authenticationLogoutHref}&redirect_uri=${encodeURIComponent(
+    logoutRedirectUrl
+  )}`;
 
   useEffect(() => {
     async function getToken() {
@@ -47,22 +57,17 @@ export default function Logout(): React.ReactElement {
 
   React.useEffect(() => {
     if (ekirjastoToken && authenticationLogoutHref) {
-      Cookie.set("SESSION", ekirjastoToken, {
-        path: "/",
-        domain: ".e-kirjasto.fi",
-        sameSite: "None",
-        secure: true
-      });
-      //document.cookie = `SESSION=${ekirjastoToken}; path=/;  domain: ".e-kirjasto.fi", SameSite=None; Secure`;
+      document.cookie = `${LOGOUT_COOKIE_PARAM}=${ekirjastoToken}; path=/;  domain: ${EKIRJASTO_DOMAIN}, SameSite=None; Secure`;
+      window.location.href = urlWithRedirect;
       signOut();
-      window.location.href = authenticationLogoutHref;
     }
   }, [
     token,
     signOut,
     authenticationLogoutHref,
     ekirjastoTokenHref,
-    ekirjastoToken
+    ekirjastoToken,
+    urlWithRedirect
   ]);
 
   if (supportedAuthMethods.length === 0) {

--- a/src/auth/LogoutWrapper.tsx
+++ b/src/auth/LogoutWrapper.tsx
@@ -1,0 +1,81 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { jsx } from "theme-ui";
+import * as React from "react";
+import useLibraryContext from "../components/context/LibraryContext";
+import { H2 } from "../components/Text";
+import Stack from "../components/Stack";
+import useUser from "components/context/UserContext";
+import LoadingIndicator from "components/LoadingIndicator";
+import { useRouter } from "next/router";
+import Head from "next/head";
+import BreadcrumbBar from "components/BreadcrumbBar";
+import useLoginRedirectUrl from "auth/useLoginRedirect";
+
+/**
+ * Redirects on successful logout
+ * Shows loader if the state is still loading
+ * Adds wrapping components for styling
+ */
+interface LogoutWrapperProps {
+  children?: React.ReactNode;
+}
+
+const LogoutWrapper = ({ children }: LogoutWrapperProps) => {
+  const { isAuthenticated, isLoading } = useUser();
+  const { catalogName } = useLibraryContext();
+  const { push } = useRouter();
+  const { successPath } = useLoginRedirectUrl();
+
+  /**
+   * If the user is unauthenticated, we can redirect
+   * to the successUrl
+   */
+  React.useEffect(() => {
+    if (!isAuthenticated) {
+      push(successPath, undefined, { shallow: true });
+    }
+  }, [isAuthenticated, push, successPath]);
+
+  return (
+    <div
+      sx={{
+        flex: 1
+      }}
+    >
+      <Head>
+        <title>Logout</title>
+      </Head>
+      <BreadcrumbBar currentLocation="Logout" />
+      <div
+        sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
+      >
+        <Stack
+          direction="column"
+          sx={{ p: 4, m: 4, border: "solid", borderRadius: "card" }}
+        >
+          <div sx={{ textAlign: "center", p: 0 }}>
+            <H2>{catalogName}</H2>
+            <h4>Logout</h4>
+          </div>
+          {/* when we just become unauthenticated, we display the
+              loading indicator until the page redirects away
+           */}
+
+          {isLoading || !isAuthenticated ? (
+            <Stack direction="column" sx={{ alignItems: "center" }}>
+              <LoadingIndicator />
+              Logging out...
+            </Stack>
+          ) : (
+            children
+          )}
+        </Stack>
+      </div>
+    </div>
+  );
+};
+
+export default LogoutWrapper;

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -51,24 +51,3 @@ export async function fetchEkirjastoToken(
 
   return json;
 }
-
-export async function logoutEkirjastoUser(url: string | undefined) {
-  if (!url) {
-    throw new ApplicationError({
-      title: "Incomplete Logout Info",
-      detail: "No URL was provided for logout"
-    });
-  }
-
-  const response = await fetchWithHeaders(url, undefined, {}, "GET");
-
-  if (!response.ok) {
-    throw new ServerError(url, response.status, {
-      detail: "Logout failed on server",
-      title: "Logout failed",
-      status: response.status
-    });
-  }
-
-  return response;
-}

--- a/src/auth/useLoginRedirect.tsx
+++ b/src/auth/useLoginRedirect.tsx
@@ -38,9 +38,14 @@ export default function useLoginRedirectUrl() {
     ? ""
     : `${window.location.origin}/api/authsuccess`;
 
+  const logoutRedirectUrl = IS_SERVER
+    ? ""
+    : `${window.location.origin}${catalogRootPath}`;
+
   return {
     fullSuccessUrl,
     successPath,
+    logoutRedirectUrl,
     authSuccessUrl
   };
 }

--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -11,6 +11,7 @@ import { isSupportedAuthType } from "auth/AuthenticationHandler";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 import useLogin from "auth/useLogin";
 import { useRouter } from "next/router";
+import useUser from "./context/UserContext";
 
 interface SignOutProps {
   color?: string;
@@ -23,6 +24,7 @@ export const SignOut: React.FC<SignOutProps> = ({
   const { authMethods } = useLibraryContext();
   const { getLogoutUrl } = useLogin();
   const { push } = useRouter();
+  const { signOut } = useUser();
 
   const supportedAuthMethods = authMethods.filter(m =>
     isSupportedAuthType(m.type)
@@ -35,6 +37,8 @@ export const SignOut: React.FC<SignOutProps> = ({
   function signOutAndClose() {
     if (method) {
       push(getLogoutUrl());
+    } else {
+      signOut()
     }
     dialog.hide();
   }

--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -6,10 +6,11 @@ import Modal from "./Modal";
 import { useDialogStore, DialogDisclosure } from "@ariakit/react/dialog";
 import Button from "./Button";
 import Stack from "./Stack";
-import useUser from "components/context/UserContext";
 import useLibraryContext from "./context/LibraryContext";
 import { isSupportedAuthType } from "auth/AuthenticationHandler";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
+import useLogin from "auth/useLogin";
+import { useRouter } from "next/router";
 
 interface SignOutProps {
   color?: string;
@@ -20,7 +21,8 @@ export const SignOut: React.FC<SignOutProps> = ({
 }: SignOutProps) => {
   const dialog = useDialogStore();
   const { authMethods } = useLibraryContext();
-  const { token, signOut, ekirjastoSignOut } = useUser();
+  const { getLogoutUrl } = useLogin();
+  const { push } = useRouter();
 
   const supportedAuthMethods = authMethods.filter(m =>
     isSupportedAuthType(m.type)
@@ -32,21 +34,8 @@ export const SignOut: React.FC<SignOutProps> = ({
 
   function signOutAndClose() {
     if (method) {
-      //Get links that are needec for successful ekirjasto logout
-      const ekirjastoTokenHref = method.links?.find(
-        link => link.rel === "ekirjasto_token"
-      )?.href;
-
-      const authenticationLogoutHref = method.links?.find(
-        link => link.rel === "logout"
-      )?.href;
-
-      //Run logout in he background
-      ekirjastoSignOut(ekirjastoTokenHref, token!, authenticationLogoutHref!);
-    } else {
-      signOut();
+      push(getLogoutUrl());
     }
-
     dialog.hide();
   }
   return (

--- a/src/components/SignOut.tsx
+++ b/src/components/SignOut.tsx
@@ -38,7 +38,7 @@ export const SignOut: React.FC<SignOutProps> = ({
     if (method) {
       push(getLogoutUrl());
     } else {
-      signOut()
+      signOut();
     }
     dialog.hide();
   }

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -8,13 +8,7 @@ import * as React from "react";
 import useSWR from "swr";
 import { BasicTokenAuthType, EkirjastoAuthType } from "types/opds1";
 import { addHours, isBefore } from "date-fns";
-import {
-  fetchEAuthToken,
-  fetchEkirjastoToken,
-  logoutEkirjastoUser
-} from "auth/ekirjastoFetch";
-import Cookie from "js-cookie";
-import { LOGOUT_COOKIE_PARAM, EKIRJASTO_DOMAIN } from "utils/constants";
+import { fetchEAuthToken, fetchEkirjastoToken } from "auth/ekirjastoFetch";
 
 type Status = "authenticated" | "loading" | "unauthenticated";
 export type UserState = {
@@ -30,11 +24,6 @@ export type UserState = {
     authenticationUrl: string | undefined
   ) => void;
   signOut: () => void;
-  ekirjastoSignOut: (
-    logoutTokenUrl: string | undefined,
-    token: string,
-    logoutUrl: string
-  ) => void;
   getEkirjastoToken: (
     token: string,
     fetchUrl: string | undefined
@@ -187,22 +176,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     mutate();
   }
 
-  async function ekirjastoSignOut(
-    logoutTokenUrl: string | undefined,
-    token: string,
-    logoutUrl: string
-  ) {
-    const ekirjastoToken = getEkirjastoToken(token, logoutTokenUrl);
-    Cookie.set(LOGOUT_COOKIE_PARAM, ekirjastoToken, {
-      path: "/",
-      domain: EKIRJASTO_DOMAIN,
-      sameSite: "None",
-      secure: true
-    });
-    logoutEkirjastoUser(logoutUrl);
-    signOut();
-  }
-
   function signOut() {
     clearCredentials();
     mutate();
@@ -247,7 +220,6 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     refetchLoans: mutate,
     signIn,
     signOut,
-    ekirjastoSignOut,
     getEkirjastoToken,
     setBook,
     setSelected,

--- a/src/pages/[library]/logout/index.tsx
+++ b/src/pages/[library]/logout/index.tsx
@@ -5,6 +5,7 @@
 import { jsx } from "theme-ui";
 import * as React from "react";
 import { NextPage, GetStaticPaths, GetStaticProps } from "next";
+import LogoutWrapper from "auth/LogoutWrapper";
 import LayoutPage from "components/LayoutPage";
 import withAppProps, { AppProps } from "dataflow/withAppProps";
 import Logout from "auth/Logout";
@@ -12,7 +13,9 @@ import Logout from "auth/Logout";
 const LogoutPage: NextPage<AppProps> = ({ library, error }) => {
   return (
     <LayoutPage library={library} error={error}>
-      <Logout />
+      <LogoutWrapper>
+        <Logout />
+      </LogoutWrapper>
     </LayoutPage>
   );
 };


### PR DESCRIPTION
## Description

This pr removes the old logout handling attempt and now handles it with a similar way to the login function, meaning we redirect the user to the logout link, with a redirect url given, so that when the logout has been finished, the user is redirected back to the ekirjasto site. The redirect goes back to /ekirjasto, aka the catalog, so that we don't accidentally end up straight back in the login view, as it is annoying. 

This pr also attempts to add the token used for logout into the cookies, but this can not be tested locally. This token is used in tunnistus to log out the user, but if it's not present the page just redirects to /ekirjasto, without actually doing the logging out from tunnistus. To test the correct functioning with the cookies, this code needs to be taken to dev, and tested there.

As it is mentioned in the Suomi.fi implementation guide:
"Uloskirjaus omasta palvelusta tulisi hoitaa ennen uloskirjauspyynnön lähettämistä Suomi.fi-tunnistukselle."
We do log out the user before requesting the remote logout, thus causing the logout button to possibly flash as a sign in button right before we redirect.

## How Can This Be Tested?

Pressing the logout button should cause the following:
1. We ask conformation about logging out
2. After confirming, we show user a loading page that says logging out, for the brief moment it takes for us to redirect to the remote logout page
3. Stuff happens in the remote logout if we have the cookie set correctly, but the user is not asked to do anything on any of the pages. If not set, the page just redirects.
4. Without any more user input, the user is redirected to the /ekirjasto page, and is now logged out

There should not be any red errors popping up during this.

Also, test what happens when directly going to the logout path /ekirjasto/logout while being logged out. User should be redirected directly to the main page or the page they were previously on.

NOTE: The webpage still remembers the previous logged in user when trying to log in again, since the cookies can't be handled locally.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
