### PR TITLE
Remove git-related files from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,9 +9,6 @@ wallaby.js
 dist
 lib
 .next
-.git
-.github
-.gitmodules
 .gitignore
 README.md
 .eslintcache


### PR DESCRIPTION
This pull request makes a minor update to the `.dockerignore` file by removing several Git-related files and directories from the ignore list. This means these files will now be included in the Docker build context.
