### PR TITLE
EKIR - Magazines loading fix

### DIFF
--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -22,25 +22,34 @@ const MagazinesFixedContent: React.FC = () => {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
   const { token, getEkirjastoToken } = useUser();
   const { slug, authMethods } = useLibraryContext();
-  const ekirMethod = authMethods.find(
-    method => method.type === EKIRJASTO_AUTH_TYPE
-  );
-  let ekirjastoToken: string | undefined;
-  if (ekirMethod && token) {
+
+   const [ekirjastoToken, setEkirjastoToken] = React.useState<string>("");
+
+   const fetchEkirjastoToken = async () => {
     try {
-      //Get the ekirjastoToken
+      // Get the ekirjasto auth method
+      const ekirMethod = authMethods.find(
+        method => method.type === EKIRJASTO_AUTH_TYPE
+      );
+      // Get the url for the token
       const ekirjastoTokenUrl = ekirMethod.links.find(
         link => link.rel === "ekirjasto_token"
       )?.href;
-      ekirjastoToken = getEkirjastoToken(token, ekirjastoTokenUrl);
+      // Fetch the ekirjasto token
+      const fetchedToken = await getEkirjastoToken(token, ekirjastoTokenUrl);
+     
+      // Set the fetched token
+      setEkirjastoToken(fetchedToken)
     } catch (error) {
-      //Can not start the reader so should show not logged in or something
+      // If the token fetch fails, it is most likely due to 401, which will be picked up
+      // elsewhere and causes a reload of the magazines page
     }
-  }
-  if (!token) {
-    //If there is no token, reload should happen
-    ekirjastoToken = undefined;
-  }
+  };
+
+  // Fetch the ekirjasto token when we show the magazines page
+  React.useEffect(() => {
+    fetchEkirjastoToken();
+  }, []);
 
   const storageKey = React.useMemo(
     () => `${MAGAZINE_CONFIG.STORAGE_KEY_PREFIX}${slug ?? "default"}`,
@@ -67,6 +76,7 @@ const MagazinesFixedContent: React.FC = () => {
       if (e.origin !== allowedOrigin || typeof e.data !== "string") return;
 
       if (e.data === "ewl:unauthorized") {
+        // Run the login attempt when if we have the needed token
         if (ekirjastoToken) {
           iframeRef.current?.contentWindow?.postMessage(
             `ewl:login:${ekirjastoToken}`,

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -23,9 +23,9 @@ const MagazinesFixedContent: React.FC = () => {
   const { token, getEkirjastoToken } = useUser();
   const { slug, authMethods } = useLibraryContext();
 
-   const [ekirjastoToken, setEkirjastoToken] = React.useState<string>("");
+  const [ekirjastoToken, setEkirjastoToken] = React.useState<string>("");
 
-   const fetchEkirjastoToken = async () => {
+  const fetchEkirjastoToken = async () => {
     try {
       // Get the ekirjasto auth method
       const ekirMethod = authMethods.find(
@@ -37,9 +37,9 @@ const MagazinesFixedContent: React.FC = () => {
       )?.href;
       // Fetch the ekirjasto token
       const fetchedToken = await getEkirjastoToken(token, ekirjastoTokenUrl);
-     
+
       // Set the fetched token
-      setEkirjastoToken(fetchedToken)
+      setEkirjastoToken(fetchedToken);
     } catch (error) {
       // If the token fetch fails, it is most likely due to 401, which will be picked up
       // elsewhere and causes a reload of the magazines page


### PR DESCRIPTION
## Description

This pr changes the way we fetch the ekirjasto token for the magazines. Previously we called a async function incorrectly. Now, we use  useState and useEffect to handle the fetching. The fetching is done when the magazines is rendered.

Here we currently don't do any error handling for the case of the ekirjasto token fetch failing, but the case of 401 is handled elsewhere, and it does trigger reload of the magazines page in the case we encounter 401.

Currently it is also possible to at least locally, look at the magazines despite being logged out, by navigating to. the /magazines directly. Though the token is not fetched again, but the magazines site seems to remember it. This might be fixed by correct handling of the logout, as the token gets invalidated, but should be kept in mind and tested when the logout functions correctly

Since errors occurred in prod, and not in a dev, we can not confirm this fixes the problem, but in any case, this solution is done with better practices than the previous one.
.
## How Can This Be Tested?

To the user, the use of a magazine should be similar to previously, but now, checking the network traffic, the token is fetched only once, and there are not multiple requests made to auth.

This can be tested by going to magazines page, and checking the network tab from the developer tools. 

This should work even if we load to the page after our circulation token has expired. Test by waiting around 10 mins, and reloading the page. Everything should work as expected.

- [ ] This change cannot be tested visually

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
