### PR TITLE
EKIRJASTO-708 Logout fix attempt

### DIFF
--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -56,8 +56,8 @@ export default function Logout(): React.ReactElement {
       // Set the fetched token
       setEkirjastoToken(fetchedToken);
     } catch (error) {
-      // If the token fetch fails, it is most likely due to 401, which will be picked up
-      // elsewhere and causes a reload of the magazines page
+      // If the token fetch fails, it is most likely due to 401,
+      // In which case, refresh happens elsewhere
     }
   };
 

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -63,7 +63,7 @@ export default function Logout(): React.ReactElement {
 
   React.useEffect(() => {
     fetchEkirjastoToken();
-  }, []);
+  });
 
   React.useEffect(() => {
     if (ekirjastoToken && authenticationLogoutHref) {
@@ -78,7 +78,13 @@ export default function Logout(): React.ReactElement {
       window.location.href = urlWithRedirect;
       signOut();
     }
-  }, [token, signOut, authenticationLogoutHref, urlWithRedirect]);
+  }, [
+    token,
+    signOut,
+    authenticationLogoutHref,
+    urlWithRedirect,
+    ekirjastoToken
+  ]);
 
   if (supportedAuthMethods.length === 0) {
     return <NoAuth />;

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -7,13 +7,13 @@ import ExternalLink from "components/ExternalLink";
 import { Text } from "components/Text";
 import LoadingIndicator from "components/LoadingIndicator";
 import { isSupportedAuthType } from "./AuthenticationHandler";
+import Cookie from "js-cookie";
 import {
   EKIRJASTO_AUTH_TYPE,
   EKIRJASTO_DOMAIN,
   LOGOUT_COOKIE_PARAM
 } from "utils/constants";
 import useUser from "components/context/UserContext";
-import { useEffect, useState } from "react";
 import useLoginRedirectUrl from "./useLoginRedirect";
 
 export default function Logout(): React.ReactElement {
@@ -21,7 +21,7 @@ export default function Logout(): React.ReactElement {
   const { logoutRedirectUrl } = useLoginRedirectUrl();
   const { authMethods } = useLibraryContext();
 
-  const [ekirjastoToken, setEkirjastoToken] = useState("");
+  const [ekirjastoToken, setEkirjastoToken] = React.useState<string>("");
 
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
@@ -29,13 +29,10 @@ export default function Logout(): React.ReactElement {
     isSupportedAuthType(m.type)
   );
 
-  const method = supportedAuthMethods.find(
+  // Get the ekirjasto auth method
+  const method = authMethods.find(
     method => method.type === EKIRJASTO_AUTH_TYPE
   )!;
-
-  const ekirjastoTokenHref = method.links?.find(
-    link => link.rel === "ekirjasto_token"
-  )?.href;
 
   // Get link for logout
   const authenticationLogoutHref = method.links?.find(
@@ -47,28 +44,41 @@ export default function Logout(): React.ReactElement {
     logoutRedirectUrl
   )}`;
 
-  useEffect(() => {
-    async function getToken() {
-      const ekirToken = await getEkirjastoToken(token!, ekirjastoTokenHref);
-      setEkirjastoToken(ekirToken);
+  const fetchEkirjastoToken = async () => {
+    try {
+      // Get the url for the token
+      const ekirjastoTokenUrl = method.links?.find(
+        link => link.rel === "ekirjasto_token"
+      )?.href;
+      // Fetch the ekirjasto token
+      const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
+
+      // Set the fetched token
+      setEkirjastoToken(fetchedToken);
+    } catch (error) {
+      // If the token fetch fails, it is most likely due to 401, which will be picked up
+      // elsewhere and causes a reload of the magazines page
     }
-    getToken();
-  });
+  };
+
+  React.useEffect(() => {
+    fetchEkirjastoToken();
+  }, []);
 
   React.useEffect(() => {
     if (ekirjastoToken && authenticationLogoutHref) {
-      document.cookie = `${LOGOUT_COOKIE_PARAM}=${ekirjastoToken}; path=/;  domain: ${EKIRJASTO_DOMAIN}, SameSite=None; Secure`;
+      // Set the session cookie
+      Cookie.set(LOGOUT_COOKIE_PARAM, ekirjastoToken, {
+        path: "/",
+        domain: EKIRJASTO_DOMAIN,
+        sameSite: "None",
+        secure: true
+      });
+
       window.location.href = urlWithRedirect;
       signOut();
     }
-  }, [
-    token,
-    signOut,
-    authenticationLogoutHref,
-    ekirjastoTokenHref,
-    ekirjastoToken,
-    urlWithRedirect
-  ]);
+  }, [token, signOut, authenticationLogoutHref, urlWithRedirect]);
 
   if (supportedAuthMethods.length === 0) {
     return <NoAuth />;


### PR DESCRIPTION
## Description

This pr attempts to fix the session cookie not being sent to the logout page correctly during logout. We change to use the js-cookie that is used in other places in the project to handle cookies. Previously the domain was not set correctly, as it just reset to the domain we create the token in, instead of the one we want so that the token can be shared between the web and tunnistus. 

## How Can This Be Tested?

- [ ] This change cannot be tested visually

When using the logout, observe the network tab in dev tools. There should be a fetch to ekirjasto token, and the request to logout start should include the cookie SESSION with the token inserted into it. Testing locally, this cookie setting does not happen, since the domain of the cookie is not one that we are under, so the cookie is not sent to the logout page, though the logout still happens locally. 

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
