### PR TITLE
EKIRJASTO-708 Possible logout fix

### DIFF
--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -11,17 +11,15 @@ import Cookie from "js-cookie";
 import {
   EKIRJASTO_AUTH_TYPE,
   EKIRJASTO_DOMAIN,
-  LOGOUT_COOKIE_PARAM
+  EKIRJASTO_SESSION_PARAM
 } from "utils/constants";
 import useUser from "components/context/UserContext";
 import useLoginRedirectUrl from "./useLoginRedirect";
 
 export default function Logout(): React.ReactElement {
-  const { token, signOut, getEkirjastoToken } = useUser();
+  const { token, session, signOut } = useUser();
   const { logoutRedirectUrl } = useLoginRedirectUrl();
   const { authMethods } = useLibraryContext();
-
-  const [ekirjastoToken, setEkirjastoToken] = React.useState<string>("");
 
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
@@ -44,47 +42,19 @@ export default function Logout(): React.ReactElement {
     logoutRedirectUrl
   )}`;
 
-  const fetchEkirjastoToken = async () => {
-    try {
-      // Get the url for the token
-      const ekirjastoTokenUrl = method.links?.find(
-        link => link.rel === "ekirjasto_token"
-      )?.href;
-      // Fetch the ekirjasto token
-      const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
-
-      // Set the fetched token
-      setEkirjastoToken(fetchedToken);
-    } catch (error) {
-      // If the token fetch fails, it is most likely due to 401,
-      // In which case, refresh happens elsewhere
-    }
-  };
-
   React.useEffect(() => {
-    fetchEkirjastoToken();
-  });
-
-  React.useEffect(() => {
-    if (ekirjastoToken && authenticationLogoutHref) {
+    if (session && authenticationLogoutHref) {
       // Set the session cookie
-      Cookie.set(LOGOUT_COOKIE_PARAM, ekirjastoToken, {
+      Cookie.set(EKIRJASTO_SESSION_PARAM, session, {
         path: "/",
         domain: EKIRJASTO_DOMAIN,
         sameSite: "None",
         secure: true
       });
-
-      window.location.href = urlWithRedirect;
-      signOut();
     }
-  }, [
-    token,
-    signOut,
-    authenticationLogoutHref,
-    urlWithRedirect,
-    ekirjastoToken
-  ]);
+    window.location.href = urlWithRedirect;
+    signOut();
+  }, [token, session, signOut, authenticationLogoutHref, urlWithRedirect]);
 
   if (supportedAuthMethods.length === 0) {
     return <NoAuth />;

--- a/src/auth/useCredentials.ts
+++ b/src/auth/useCredentials.ts
@@ -6,6 +6,7 @@ import { NextRouter, useRouter } from "next/router";
 import { generateCredentials } from "utils/auth";
 import {
   EKIRJASTO_AUTH_TYPE,
+  EKIRJASTO_SESSION_PARAM,
   EKIRJASTO_TOKEN_PARAM,
   SAML_LOGIN_QUERY_PARAM
 } from "utils/constants";
@@ -42,8 +43,8 @@ export default function useCredentials(
   >(getCredentialsCookie(slug, authenticationUrl));
   // sync up cookie state with react state
   React.useEffect(() => {
-    const cookie = getCredentialsCookie(slug, authenticationUrl);
-    if (cookie) setCredentialsState(cookie);
+    const cookieCredentials = getCredentialsCookie(slug, authenticationUrl);
+    if (cookieCredentials) setCredentialsState(cookieCredentials);
   }, [authenticationUrl, slug]);
 
   // set both cookie and state credentials
@@ -59,6 +60,7 @@ export default function useCredentials(
   const clear = React.useCallback(() => {
     setCredentialsState(undefined);
     clearCredentialsCookie(slug);
+    clearSessionCookie(slug);
   }, [slug]);
 
   // use credentials from browser url if they exist
@@ -97,10 +99,21 @@ function cookieNameEkirjasto(): string {
   const AUTH_COOKIE_NAME = EKIRJASTO_TOKEN_PARAM;
   return AUTH_COOKIE_NAME;
 }
+
+/**
+ * When using ekirjasto authentication, we don't use scoping to a particular library
+ * @returns ekirjasto session cookie name
+ */
+function cookieNameEkirjastoSession(): string {
+  const AUTH_COOKIE_NAME = EKIRJASTO_SESSION_PARAM;
+  return AUTH_COOKIE_NAME;
+}
 /**
  * Get credentials from cookies.
  * We assume the token is in access_token cookie, and that it is
  * of the Ekirjasto Authentication type
+ *
+ * There is also a token defining the session that is used for logout
  *
  * @param librarySlug Library slug, that is useful if we have multiple libraries
  * @param authenticationUrl AuthenticationUrl where we make refresh requests
@@ -113,6 +126,8 @@ function getCredentialsCookie(
   if (librarySlug === "ekirjasto") {
     // Get access token, for ekirjasto login credentials
     const accessToken = Cookie.get(cookieNameEkirjasto());
+    const session = Cookie.get(cookieNameEkirjastoSession());
+
     if (!accessToken) {
       return undefined;
     }
@@ -120,6 +135,7 @@ function getCredentialsCookie(
     const authCredentials: AuthCredentials = {
       token: `Bearer ${accessToken}`,
       methodType: OPDS1.EkirjastoAuthType,
+      session: session,
       authenticationUrl: authenticationUrl ? authenticationUrl : undefined
     };
     // Return the credentials
@@ -151,6 +167,12 @@ function clearCredentialsCookie(librarySlug: string | null) {
     Cookie.remove(cookieNameEkirjasto());
   } else {
     Cookie.remove(cookieName(librarySlug));
+  }
+}
+
+function clearSessionCookie(librarySlug: string | null) {
+  if (librarySlug === "ekirjasto") {
+    Cookie.remove(cookieNameEkirjastoSession());
   }
 }
 

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -32,6 +32,7 @@ export type UserState = {
   setSelected: (book: AnyBook, id?: string) => void;
   error: any;
   token: string | undefined;
+  session: string | undefined;
   clearCredentials: () => void;
 };
 
@@ -225,6 +226,7 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     setSelected,
     error,
     token: stringifyToken(credentials),
+    session: credentials?.session,
     clearCredentials
   };
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -114,6 +114,7 @@ export type AuthCredentialsToken = string | Token | undefined;
 export interface AuthCredentials {
   methodType: AppAuthMethod["type"];
   token: AuthCredentialsToken;
+  session?: string;
   authenticationUrl?: string;
 }
 

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -3,7 +3,11 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { serialize } from "cookie";
 import { APP_CONFIG } from "utils/env";
 import { buildLibraryData, fetchAuthDocument } from "dataflow/getLibraryData";
-import { EKIRJASTO_AUTH_TYPE, EKIRJASTO_SESSION_PARAM, EKIRJASTO_TOKEN_PARAM } from "utils/constants";
+import {
+  EKIRJASTO_AUTH_TYPE,
+  EKIRJASTO_SESSION_PARAM,
+  EKIRJASTO_TOKEN_PARAM
+} from "utils/constants";
 
 type ResponseData = {
   message: string;
@@ -30,17 +34,16 @@ export default async function handler(
       );
 
       // Set the circulation token and authentication token as cookies that can be read on the other page and stored
-      res.setHeader(
-        "Set-Cookie",
-        [serialize(EKIRJASTO_TOKEN_PARAM, accessToken, {
+      res.setHeader("Set-Cookie", [
+        serialize(EKIRJASTO_TOKEN_PARAM, accessToken, {
           httpOnly: false,
           path: "/"
-        }), 
+        }),
         serialize(EKIRJASTO_SESSION_PARAM, token, {
           httpOnly: false,
           path: "/"
-        })]
-      );
+        })
+      ]);
 
       // Redirect to back to ekirjasto
       res.writeHead(302, { Location: "/ekirjasto" });

--- a/src/pages/api/authsuccess.ts
+++ b/src/pages/api/authsuccess.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { serialize } from "cookie";
 import { APP_CONFIG } from "utils/env";
 import { buildLibraryData, fetchAuthDocument } from "dataflow/getLibraryData";
-import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
+import { EKIRJASTO_AUTH_TYPE, EKIRJASTO_SESSION_PARAM, EKIRJASTO_TOKEN_PARAM } from "utils/constants";
 
 type ResponseData = {
   message: string;
@@ -29,13 +29,17 @@ export default async function handler(
         token
       );
 
-      // Set the circulation token as a cookie that can be read on the other page and stored
+      // Set the circulation token and authentication token as cookies that can be read on the other page and stored
       res.setHeader(
         "Set-Cookie",
-        serialize("access_token", accessToken, {
+        [serialize(EKIRJASTO_TOKEN_PARAM, accessToken, {
           httpOnly: false,
           path: "/"
-        })
+        }), 
+        serialize(EKIRJASTO_SESSION_PARAM, token, {
+          httpOnly: false,
+          path: "/"
+        })]
       );
 
       // Redirect to back to ekirjasto

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -8,6 +8,6 @@ export const LOGIN_REDIRECT_QUERY_PARAM = "nextUrl";
 export const LOGIN_ERROR_QUERY_PARAM = "loginError";
 export const SAML_LOGIN_QUERY_PARAM = "access_token";
 export const EKIRJASTO_TOKEN_PARAM = "access_token";
+export const EKIRJASTO_SESSION_PARAM = "SESSION";
 export const EKIRJASTO_AUTH_TYPE = "http://e-kirjasto.fi/authtype/ekirjasto";
-export const LOGOUT_COOKIE_PARAM = "SESSION";
 export const EKIRJASTO_DOMAIN = ".e-kirjasto.fi";


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This pr adds the handling of the token that is received from authentication upon successful login. The token is stored in the user's credentials, and set to the logout request.

This should fix the case of using a different token to logout than what we get from the login. This token is stale after login, but the logout portal doesn't really care, and despite it being unable to be used for authenticating into magazines, it can be used to handle the login/logout session, thus we name it session token, instead of something like authentication token.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

The logout should function as it did before, due to the domain problems with delivering the token, but when tested in dev, the logout request should have a cookie called SESSION, that has the same value that we get from the successful login, that can be seen in the call that goes to /authsuccess, in the response body.

Logout should then not redirect into the middle of the previous person's login, when logging out and then logging back in.

This token should also be cleared after logout, so it should not be seen anymore when we redirect to /ekirjasto after logout.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
