### PR TITLE
EKIRJASTO-802 Fix book buttons and passphrase display issues

### DIFF
--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -25,7 +25,11 @@ import useUser from "components/context/UserContext";
 import Stack from "components/Stack";
 import CancelOrReturn from "components/CancelOrReturn";
 import FulfillmentButton from "components/FulfillmentButton";
-import { getFulfillmentFromLink } from "utils/fulfill";
+import {
+  DownloadFulfillment,
+  getFulfillmentFromLink,
+  ReadExternalFulfillment
+} from "utils/fulfill";
 import BookStatus from "components/BookStatus";
 import Link from "./Link";
 import { APP_CONFIG } from "utils/env";
@@ -218,6 +222,11 @@ const Description: React.FC<{ book: AnyBook; className?: string }> = ({
   );
 };
 
+// Render the main action buttons for book list, for example
+// Borrow, Reserve, Download, Read online, Cancel and Return
+//
+// Note: adding or removing book from Favorites is a secondary action
+// and handled separately via SelectBookCard component
 const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
   const { t } = useTranslation();
 
@@ -245,27 +254,55 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
   }
 
   if (bookIsFulfillable(book)) {
-    // we will show a fulfillment button if there is only one option
+    // E-library has currently two possible fulfillment
+    // options for a book: download and read online.
+    // We show buttons for these options in the book list
+    // if they are available for the book,
+    // as well as the cancel reservation/return book button.
 
-    const showableLinks = book.fulfillmentLinks.filter(
-      link => link.supportLevel === "show"
+    // first filter the links that should be shown
+    // and then extract Fulfillments from them
+    const showableFulfillments = book.fulfillmentLinks
+      .filter(link => link.supportLevel === "show")
+      .map(getFulfillmentFromLink);
+
+    // find the first fulfillment that is a DownloadFulfillment
+    // that has a type property 'download'
+    const downloadFulfillment = showableFulfillments.find(
+      (fulfillment): fulfillment is DownloadFulfillment =>
+        fulfillment.type === "download"
     );
 
-    const showableFulfillments = showableLinks.map(getFulfillmentFromLink);
-    const singleFulfillment =
-      showableFulfillments.length === 1 ? showableFulfillments[0] : undefined;
+    // find the first fulfillment that is a ReadExternalFulfillment
+    // and has a type property 'read-online-external'
+    const readOnlineFulfillment = showableFulfillments.find(
+      (fulfillment): fulfillment is ReadExternalFulfillment =>
+        fulfillment.type === "read-online-external"
+    );
 
     return (
       <>
+        {/* first render "Return" book button */}
         <CancelOrReturn
           url={book.revokeUrl}
           loadingText={t("bookList.returning")}
           id={book.id}
           text={t("bookList.return")}
         />
-        {singleFulfillment && (
+
+        {/* then render "Download LCP EPUB" button, if available */}
+        {downloadFulfillment && (
           <FulfillmentButton
-            details={singleFulfillment}
+            details={downloadFulfillment}
+            book={book}
+            isPrimaryAction
+          />
+        )}
+
+        {/* render "Read online" button also, if available */}
+        {readOnlineFulfillment && (
+          <FulfillmentButton
+            details={readOnlineFulfillment}
             book={book}
             isPrimaryAction
           />
@@ -274,6 +311,9 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
     );
   }
 
+  // this book is not
+  // borrowable, reservable, on hold, reserved or fulfillable,
+  // so just return null instead of main action buttons
   return null;
 };
 

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -25,10 +25,7 @@ import useUser from "components/context/UserContext";
 import Stack from "components/Stack";
 import CancelOrReturn from "components/CancelOrReturn";
 import FulfillmentButton from "components/FulfillmentButton";
-import {
-  getFulfillmentFromLink,
-  shouldRedirectToCompanionApp
-} from "utils/fulfill";
+import { getFulfillmentFromLink } from "utils/fulfill";
 import BookStatus from "components/BookStatus";
 import Link from "./Link";
 import { APP_CONFIG } from "utils/env";
@@ -249,12 +246,9 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
 
   if (bookIsFulfillable(book)) {
     // we will show a fulfillment button if there is only one option
-    // and we are not supposed to redirect the user to the companion app
+
     const showableLinks = book.fulfillmentLinks.filter(
       link => link.supportLevel === "show"
-    );
-    const shouldRedirectUser = shouldRedirectToCompanionApp(
-      book.fulfillmentLinks
     );
 
     const showableFulfillments = showableLinks.map(getFulfillmentFromLink);
@@ -269,13 +263,13 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
           id={book.id}
           text={t("bookList.return")}
         />
-        {singleFulfillment && !shouldRedirectUser ? (
+        {singleFulfillment && (
           <FulfillmentButton
             details={singleFulfillment}
             book={book}
             isPrimaryAction
           />
-        ) : null}
+        )}
       </>
     );
   }

--- a/src/components/bookDetails/BookPassphrase.tsx
+++ b/src/components/bookDetails/BookPassphrase.tsx
@@ -47,7 +47,8 @@ const BookPassphrase: React.FC<BookPassphraseProps> = ({ book }) => {
   // define style for the Stack component
   const stackStyle: React.CSSProperties = {
     alignItems: "flex-start",
-    marginBottom: "16px"
+    marginBottom: "16px",
+    marginTop: "16px"
   };
 
   // component is only rendered if the

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -307,11 +307,18 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     link => link.supportLevel !== "unsupported"
   );
 
-  // Get the availability, holds, copies and passphrases
+  // Get the availability, holds and copies
   // from the borrow link, and if there is no borrow link,
   // get it from the first possible acquisition link
-  const { availability, holds, copies, passphrases } =
+  const { availability, holds, copies } =
     borrowLink ?? acquisitionLinks[0] ?? {};
+
+  // find the first valid acquisition link
+  // (could be undefined, if no suitable link is found)
+  // and then extract the passphrases from the link
+  const passphrases = acquisitionLinks.find(link =>
+    isValidAcquisitionLinkWithPassphrases(link)
+  )?.passphrases;
 
   const format = bookIsAudiobook({ ...entry.unparsed, raw: entry.unparsed })
     ? "Audiobook"

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -30,6 +30,7 @@ import {
 } from "interfaces";
 import {
   EPUB_MEDIA_TYPES,
+  LcpDrmMediaType,
   IncorrectAdobeDrmMediaType,
   PdfMediaType
 } from "types/opds1";
@@ -199,6 +200,25 @@ function createUnselectBookUrl(links: OPDSLink[], feedUrl: string) {
     return resolve(feedUrl, alternateLink.href + "/unselect_book");
   }
   return null;
+}
+
+// helper function to check if an acquisition link has passphrases
+// and is of valid type
+function isValidAcquisitionLinkWithPassphrases(
+  link: OPDSAcquisitionLink
+): boolean {
+  // check that rel is "http://opds-spec.org/acquisition"
+  const isGenericRel = link.rel === OPDSAcquisitionLink.GENERIC_REL;
+
+  // check that type is "application/vnd.readium.lcp.license.v1.0+json"
+  // note: "application/vnd.adobe.adept+xml" is not acceptable
+  const isLCPType = link.type === LcpDrmMediaType;
+
+  // check that the passphrases object actually exists
+  const hasPassphrases = !!link.passphrases;
+
+  // return true if all checks pass
+  return isGenericRel && isLCPType && hasPassphrases;
 }
 
 /**


### PR DESCRIPTION
## Description

- This pull request adds three small fixes related to book passphrase or book buttons

- Book download and read online buttons are always displayed when available
  - restriction to show a fulfillment button (if exactly only one was available) was removed from `BookList` component
  - fulfillment buttons are now visible both in book list views and book's detail view
  
- Book passphrase is always displayed if it is available
  - only valid fulfillment links are used for passphrase extraction
  - new helper function was added to `parse.ts` to help check for valid acquisition links with passphrases
  
- Book passphrase has additional space at the top
  - missing top margin was added to `BookPassphrase` component
  - there is now space between the passphrase instructions text and favorite button


## How can this be tested?

<!--- Please describe in detail how one can test this -->

- Check the BookList view:
  - the book passphrase is not displayed
  - book return/cancel button is visible
  - if book has only download option, only download button is visible
  - both book download and read online buttons are visible when the book has multiple fulfillment options

- Check the BookDetails view:
  - the book passphrase is displayed for all eBooks (check Finnish and English eBooks)
  - book return/cancel button is visible
  - if book has only download option, only download button is visible
  - both book download and read online buttons are visible when the book has multiple fulfillment options

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [x] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
