### PR TITLE
EKIRJASTO-808 Remove next-env.d.ts from version control and update ESLint ignore settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -119,5 +119,6 @@ module.exports = {
         "i18next/no-literal-string": "off"
       }
     }
-  ]
+  ],
+  ignorePatterns: ["_next/", "next-env.d.ts"]
 };

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 /.next/
 /out/
 _next
+next-env.d.ts
 
 # production
 /build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Description

- This pull request removes the file `next-env.d.ts` from version control
   - this file is automatically generated by Next.js for type references
   - it is recommended not to track this file in version control
- ESLint configuration was also updated to ignore the `_next` folder and the `next-env.d.ts` file
  - unnecessary linting errors could come from automatically generated Next files
- [EKIRJASTO-808](https://jira.it.helsinki.fi/browse/EKIRJASTO-808) 

## How can this be tested?

- review `.gitignore` file
  - check that file _next-env.d.ts_ and folder __next_ are listed
  - check that file _next-env.d.ts_ is removed from repository
  - check that _next-env.d.ts_ file is generated automatically during `npm run build`
- review `.eslintrc.js` file
  - check that _next-env.d.ts_ and  __next_ are listed as ignored
  - run `npm run lint` and confirm that there are no linting errors from next autogenerated files 


<!--- Leave a comment if your change affects other areas of the code-->

- [ ] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
