### PR TITLE
EKIRJASTO-783 Fetch content in locale language

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ test("fetches search description", async () => {
   // expected. In this case once for the collection, then for it's search
   // description.
   expect(mockedSWR).toHaveBeenCalledWith(
-    ["/collection", "user-token"],
+    ["/collection", "user-token", "en"],
     expect.anything()
   );
   expect(mockedSWR).toHaveBeenCalledWith("/search-data-url", expect.anything());

--- a/README.md
+++ b/README.md
@@ -10,48 +10,6 @@ The `web-patron` application serves as a way for libraries to publish their coll
 
 This app can support many libraries, each at their own url: `http://example.com/library1` can be one library, and `http://example.com/library2` another library. You configure the libraries for the app in the [config file](#configuration-file).
 
-<!-- ## Community Demo
-
-- Community Preview - [https://web.librarysimplified.org](https://web.librarysimplified.org)
-
-In addition to the preview of the production branch, we also have previews of the `qa` and `dev` branches:
-
-- qa - [https://qa-web.librarysimplified.org](https://qa-web.librarysimplified.org)
-- dev - [https://dev-web.librarysimplified.org](https://dev-web.librarysimplified.org)
-
-Finally, every PR in this repository has a unique preview deployment so proposed changes can be previewed with any library in the community config file.
-
-__To have your library added to the demo, register it with NYPL's Library Registry.__ -->
-
-# Table of Contents
-
-- [web-patron](#web-patron)
-  - [Background](#background)
-  <!-- * [Demo](#community-demo) -->
-- [Configuring the App](#configuring-the-app)
-  - [Configuration File](#configuration-file)
-  - [Environment Variables](#environment-variables)
-  - [Manager, Registry, and Application Configurations](#manager--registry--and-application-configurations)
-- [Development](#development)
-  - [Contributing](#contributing)
-    - [GPG signed commit](#gpg-signed-commit)
-  - [Installing Dependencies](#installing-dependencies)
-  - [Running the Application](#running-the-application)
-    - [ENV Vars and Building](#env-vars-and-building)
-    - [Useful Scripts](#useful-scripts)
-  - [Testing](#testing)
-    - [Context and useful spies](#context-and-useful-spies)
-    - [Running tests](#running-tests)
-    - [Example](#example)
-  - [Links and Routing](#links-and-routing)
-- [Deploying](#deploying)
-  - [Build a docker container](#build-a-docker-container)
-    - [Running the docker container](#running-the-docker-container)
-    - [From the command line](#from-the-command-line)
-    - [Using `docker-compose`](#using--docker-compose-)
-    - [Helpful commands](#helpful-commands)
-    - [Credits](#credits)
-
 # Configuring the App
 
 ## Configuration File
@@ -253,9 +211,6 @@ Key settings:
 #### `appLocales.ts`
 
 This file is intended to collect all of the app’s locale settings and related helper functions in one place.
-
-- it defines which languages are supported in the app, the available translation locales and the locale used for testing
-- it provides helper functions for working with locales and the `AppLocale` type definition for safer locale handling
 
 ### JSON structure for translations files
 

--- a/README.md
+++ b/README.md
@@ -250,6 +250,13 @@ Key settings:
   - `translations:sync` Sync Finnish and Swedish files with the English file
   - `translations:ci` Fail builds when translations are outdated
 
+#### `appLocales.ts`
+
+This file is intended to collect all of the app’s locale settings and related helper functions in one place.
+
+- it defines which languages are supported in the app, the available translation locales and the locale used for testing
+- it provides helper functions for working with locales and the `AppLocale` type definition for safer locale handling
+
 ### JSON structure for translations files
 
 Translations are stored in flat JSON files named `translations.json`, with one file for each supported language. The JSON files consist of key-value pairs, where the key is a unique identifier for the translation and the value is the actual translated string.  The translation keys within these files can be structured using a dot notation, like `bookDetails.publisher`, but using this structure is optional. Nesting is not used, which makes it easier to retrieve and sort the translations.

--- a/appLocales.ts
+++ b/appLocales.ts
@@ -2,3 +2,48 @@
 
 // This file contains i18n locale (language) definitions for the E-kirjasto app
 // Import these consts and functions to files where you need app locales
+
+// ******************************************************************
+// APP LOCALES
+
+// define specific AppLocale type for locales
+export type AppLocale = typeof APP_LOCALES[number];
+
+// define all the supported locales for app:
+// - Finnish (fi)
+// - Swedish (sv)
+// - English (en)
+// No regions are used in these language codes
+export const APP_LOCALES = ["fi", "sv", "en"] as const;
+
+// define the default language for the app,
+// it should be Finnish if no other information
+// of user's preferred language is available
+export const APP_DEFAULT_LOCALE: AppLocale = "fi";
+
+// define the fallback locale to be used
+// if a key is missing in the current locale,
+// we usually have at least the English translations available
+export const APP_FALLBACK_LOCALE: AppLocale = "en";
+
+// ******************************************************************
+// TRANSLATION FILES:
+
+// define the language that is the base for app translations
+// this means that public/locales/en/translation.json
+// is our primary source language
+export const TRANSLATIONS_PRIMARY_LOCALE: AppLocale = "en";
+
+// define other languages that the app is translated to
+// these secondary locales are synced with the source locale,
+// which means that FI and SV files follow the updates made to EN file
+export const TRANSLATIONS_SECONDARY_LOCALES: AppLocale[] = ["fi", "sv"];
+
+// ******************************************************************
+// TESTS:
+
+// define the default locale that the tests should use
+// English is set as locale to test mock router
+// so we can write tests using the English strings
+// note: testing locale is defined as type of string
+export const APP_DEFAULT_LOCALE_FOR_TESTING: string = "en";

--- a/appLocales.ts
+++ b/appLocales.ts
@@ -1,0 +1,4 @@
+// applocales.ts
+
+// This file contains i18n locale (language) definitions for the E-kirjasto app
+// Import these consts and functions to files where you need app locales

--- a/appLocales.ts
+++ b/appLocales.ts
@@ -47,3 +47,59 @@ export const TRANSLATIONS_SECONDARY_LOCALES: AppLocale[] = ["fi", "sv"];
 // so we can write tests using the English strings
 // note: testing locale is defined as type of string
 export const APP_DEFAULT_LOCALE_FOR_TESTING: string = "en";
+
+// ******************************************************************
+// HELPER FUNCTIONS:
+
+// define type guard function
+// that checks if the string given as parameter is of type AppLocale
+export function isAppLocale(locale: string): locale is AppLocale {
+  // get list of supported locales as string
+  const supportedLocales = APP_LOCALES as readonly string[];
+
+  // returns true only if the locale is a supported locale
+  return supportedLocales.includes(locale);
+}
+
+// function that returns a valid app locale after checking it
+// or the app default locale as fallback
+// locale to check is given as a string parameter
+export function normaliseLocale(rawLocale?: string): AppLocale {
+  // check that we have a input
+  if (!rawLocale) {
+    // no input, just return default locale
+    return APP_DEFAULT_LOCALE;
+  }
+
+  // try to format the locale
+  const normalisedLocale = formatRawLocale(rawLocale);
+
+  // check that locale is valid and supported in app
+  if (!normalisedLocale || !isAppLocale(normalisedLocale)) {
+    // no locale to check after normalising or
+    // normalised locale is not valid app locale
+    // just return default locale
+    return APP_DEFAULT_LOCALE;
+  }
+
+  // return valid app locale
+  return normalisedLocale;
+}
+
+// Helper function that returns raw locale string formatted
+function formatRawLocale(rawLocale: string): string {
+  // first trim the input and remove any
+  // leading or trailign whitespaces
+  const trimmedLocale = rawLocale.trim();
+
+  // if for some reason region part is present,
+  // try separate it from the language code,
+  // for example format "en-US" to just "en"
+  const baseLocale = trimmedLocale.split("-")[0];
+
+  // change to lowercase just in case
+  const formattedLocale = baseLocale.toLowerCase();
+
+  // return after formatting
+  return formattedLocale;
+}

--- a/i18next.config.ts
+++ b/i18next.config.ts
@@ -24,16 +24,23 @@
 // import helper function to create the configuration
 import { defineConfig } from "i18next-cli";
 
+// import Ekirjasto web app locale definitions
+import {
+  APP_LOCALES,
+  TRANSLATIONS_PRIMARY_LOCALE,
+  TRANSLATIONS_SECONDARY_LOCALES
+} from "./appLocales";
+
 // define the supported languages
 // E-kirjasto app has three languages: English, Finnish, Swedish
-const appLocales = ["fi", "sv", "en"];
+const appLocales = [...APP_LOCALES];
 
 // set the primary, "main" language for the application
 // English translations and keys are the "base" for other translations
-const primaryLanguage = "en";
+const primaryLanguage = TRANSLATIONS_PRIMARY_LOCALE;
 
 // define secondary languages that will be supported: Finnish and Swedish
-const secondaryLanguages = ["fi", "sv"];
+const secondaryLanguages = TRANSLATIONS_SECONDARY_LOCALES;
 
 // define the functions used for translation in the code
 // t function is used for retrieving translation strings
@@ -41,6 +48,10 @@ const translationFunctions = ["t"];
 
 // define the default namespace (file) for translations as "translations"
 const defaultTranslationNamespace = "translations";
+
+// define a default value that is used
+// for missing keys in secondary languages
+const defaultTranslationValue = "";
 
 // define the input file patterns to search for translation keys
 // We include all .tsx and .jsx files in the components and pages directories
@@ -95,6 +106,7 @@ const ignoredAttributes = [
 //    sorted alphabetically in translation.json files after extraction
 const extractConfig = {
   defaultNS: defaultTranslationNamespace,
+  defaultValue: defaultTranslationValue,
   functions: translationFunctions,
   ignore: ignoredFiles,
   ignoredAttributes,

--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -12,6 +12,8 @@ const path = require("path");
 // The default language for the application is Finnish,
 // which is also used as the fallback language
 // if a translation is missing.
+// Note: these duplicate locale definitions are used until
+// project is changed to support typescript next config
 const i18nConfig = {
   defaultLocale: "fi",
   locales: ["fi", "sv", "en"]

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -125,6 +125,7 @@
   "languageName.FI": "Finnish",
   "languageName.SV": "Swedish",
   "languageSelector": "Select page language",
+  "listFilters.label": "Book format",
   "loadingIndicator.loading": "Loading...",
   "magazineFilters.allMagazines": "All magazines",
   "magazineFilters.allSubjects": "All subjects",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -125,6 +125,7 @@
   "languageName.FI": "Suomi",
   "languageName.SV": "Ruotsi",
   "languageSelector": "Valitse sivun kieli",
+  "listFilters.label": "Kirjamuoto",
   "loadingIndicator.loading": "Ladataan...",
   "magazineFilters.allMagazines": "Kaikki lehdet",
   "magazineFilters.allSubjects": "Kaikki aiheet",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -125,6 +125,7 @@
   "languageName.FI": "Finska",
   "languageName.SV": "Svenska",
   "languageSelector": "Välj sidspråk",
+  "listFilters.label": "Bokformat",
   "loadingIndicator.loading": "Laddar...",
   "magazineFilters.allMagazines": "Alla tidskrifter",
   "magazineFilters.allSubjects": "Alla ämnen",

--- a/src/auth/__tests__/BasicAuthForm.test.tsx
+++ b/src/auth/__tests__/BasicAuthForm.test.tsx
@@ -115,7 +115,7 @@ test("submit by clicking login button", async () => {
       headers: {
         Authorization: token,
         "X-Requested-With": "XMLHttpRequest",
-        "Accept-Language": "*"
+        "Accept-Language": "en"
       },
       method: "GET"
     });
@@ -159,7 +159,7 @@ test("displays server error", async () => {
     headers: {
       Authorization: "token",
       "X-Requested-With": "XMLHttpRequest",
-      "Accept-Language": "*"
+      "Accept-Language": "en"
     },
     method: "GET"
   });
@@ -241,7 +241,7 @@ test("submits with no password input", async () => {
       headers: {
         Authorization: token,
         "X-Requested-With": "XMLHttpRequest",
-        "Accept-Language": "*"
+        "Accept-Language": "en"
       },
       method: "GET"
     });

--- a/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
+++ b/src/auth/__tests__/BasicTokenAuthHandler.test.tsx
@@ -159,7 +159,7 @@ test("submit by clicking login button", async () => {
       headers: {
         Authorization: `Bearer ${firstToken}`,
         "X-Requested-With": "XMLHttpRequest",
-        "Accept-Language": "*"
+        "Accept-Language": "en"
       },
       method: "GET"
     });
@@ -197,7 +197,7 @@ test("fetch new token if token has expired", async () => {
       headers: {
         Authorization: firstToken,
         "X-Requested-With": "XMLHttpRequest",
-        "Accept-Language": "*"
+        "Accept-Language": "en"
       },
       method: "GET"
     });

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -35,6 +35,7 @@ import Link from "./Link";
 import { APP_CONFIG } from "utils/env";
 import SelectBookCard from "./SelectBookCard";
 import { useTranslation, TFunction } from "next-i18next";
+import { useRouter } from "next/router";
 
 const ListLoadingIndicator = () => {
   const { t } = useTranslation();
@@ -60,13 +61,14 @@ export const InfiniteBookList: React.FC<{ firstPageUrl: string }> = ({
   firstPageUrl
 }) => {
   const { token } = useUser();
+  const { locale } = useRouter();
   const getKey = (pageIndex: number, previousData: CollectionData | null) => {
     // first page, no previous data
-    if (pageIndex === 0) return [firstPageUrl, token];
+    if (pageIndex === 0) return [firstPageUrl, token, locale];
     // reached the end
     if (!previousData?.nextPageUrl) return null;
     // otherwise return the next page url
-    return [previousData.nextPageUrl, token];
+    return [previousData.nextPageUrl, token, locale];
   };
   const { data, size, error, setSize } = useSWRInfinite(
     getKey,

--- a/src/components/CancelOrReturn.tsx
+++ b/src/components/CancelOrReturn.tsx
@@ -9,6 +9,7 @@ import Button from "components/Button";
 import { Text } from "components/Text";
 import useError from "hooks/useError";
 import { useTranslation } from "next-i18next";
+import { useRouter } from "next/router";
 
 const CancelOrReturn: React.FC<{
   text: string;
@@ -21,6 +22,7 @@ const CancelOrReturn: React.FC<{
   const [loading, setLoading] = React.useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   async function cancelReservation(revokeUrl: string) {
     clearError();
@@ -30,7 +32,7 @@ const CancelOrReturn: React.FC<{
     }
     setLoading(true);
     try {
-      const newBook = await fetchBook(revokeUrl, catalogUrl, token);
+      const newBook = await fetchBook(revokeUrl, catalogUrl, token, locale);
       setBook(newBook, id);
     } catch (e) {
       handleError(e);

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -19,6 +19,7 @@ export const Collection: React.FC<{
   title?: string;
 }> = ({ title }) => {
   const { collection, collectionUrl, isValidating, error } = useCollection();
+  const { t } = useTranslation();
 
   const isLoading = !collection && isValidating;
 
@@ -26,17 +27,22 @@ export const Collection: React.FC<{
   const hasBooks = collection?.books && collection.books.length > 0;
   const pageTitle = isLoading ? "" : title ?? collection?.title ?? "Collection";
 
+  // get the breadcrumbs context
+  const { storedBreadcrumbs, setStoredBreadcrumbs } = useBreadcrumbContext();
+
+  // build the breadcrumbs for the current collection.
+  // note: collection is always fetched with the current locale,
+  // so when the user changes language, this function should
+  // be also run automatically and the builder should
+  // compute new breadcrumbs using the new locale
   const collectionBreadcrumbs = React.useMemo(
     () => computeBreadcrumbs(collection),
     [collection]
   );
 
-  const { storedBreadcrumbs, setStoredBreadcrumbs } = useBreadcrumbContext();
-
-  const { t } = useTranslation();
-
+  // effect that updates the breadcrumbs stored in context
+  // whenever collectionBreadcrumbs changes
   React.useEffect(() => {
-    //store the updated breadcrumbs in context
     setStoredBreadcrumbs(collectionBreadcrumbs);
   }, [collectionBreadcrumbs, setStoredBreadcrumbs]);
 

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -14,12 +14,14 @@ import ApplicationError from "errors";
 import ErrorComponent from "components/Error";
 import useBreadcrumbContext from "../components/context/BreadcrumbContext";
 import { useTranslation } from "next-i18next";
+import { useRouter } from "next/router";
 
 export const Collection: React.FC<{
   title?: string;
 }> = ({ title }) => {
   const { collection, collectionUrl, isValidating, error } = useCollection();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   const isLoading = !collection && isValidating;
 
@@ -34,10 +36,13 @@ export const Collection: React.FC<{
   // note: collection is always fetched with the current locale,
   // so when the user changes language, this function should
   // be also run automatically and the builder should
-  // compute new breadcrumbs using the new locale
+  // compute new breadcrumbs using the new locale.
+  // The reason locale is passed here is only to help
+  // translate some breadcrumbs
   const collectionBreadcrumbs = React.useMemo(
-    () => computeBreadcrumbs(collection),
-    [collection]
+    // this is run whenever collection or locale changes
+    () => computeBreadcrumbs(collection, locale),
+    [collection, locale]
   );
 
   // effect that updates the breadcrumbs stored in context

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -81,6 +81,7 @@ const ReadOnlineExternal: React.FC<{
   const [loading, setLoading] = React.useState(false);
   const { error, handleError, clearError } = useError();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   async function open() {
     setLoading(true);
@@ -90,7 +91,8 @@ const ReadOnlineExternal: React.FC<{
       // provided function
       const { url: externalReaderUrl } = await details.getLocation(
         catalogUrl,
-        token
+        token,
+        locale
       );
 
       // we are about to open the book, so send a track event
@@ -150,6 +152,7 @@ const DownloadButton: React.FC<{
   const { catalogUrl } = useLibraryContext();
   const { token } = useUser();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   async function download() {
     setLoading(true);
@@ -159,7 +162,7 @@ const DownloadButton: React.FC<{
         url: downloadUrl,
         token: downloadToken,
         lcpContentType
-      } = await details.getLocation(catalogUrl, token);
+      } = await details.getLocation(catalogUrl, token, locale);
 
       const downloadContentType = lcpContentType ?? details?.contentType;
       await downloadFile(

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,19 +1,13 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 
+import { APP_LOCALES, AppLocale, isAppLocale } from "../../appLocales";
 import { jsx } from "theme-ui";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
 import Button from "components/Button";
 import React from "react";
 import Stack from "components/Stack";
-
-// define enums that match the Next.js i18n locales
-export enum Language {
-  FI = "fi",
-  SV = "sv",
-  EN = "en"
-}
 
 // define style for the language selector stack
 // (the container for language buttons)
@@ -57,15 +51,6 @@ interface LanguageSelectorProps {
   // no properties for this component yet
 }
 
-// helper function (type guard) that checks
-// if a locale is a valid Language
-// for example "de" is not a valid language code in our app
-function isLanguage(locale: string | undefined): locale is Language {
-  return (
-    locale === Language.FI || locale === Language.SV || locale === Language.EN
-  );
-}
-
 // main LanguageSelector component
 const LanguageSelector: React.FC<LanguageSelectorProps> = () => {
   // get translation function t from the useTranslation hook,
@@ -76,14 +61,20 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = () => {
   // used for reading the current locale and changing the language in the URL
   const router = useRouter();
 
+  // first define currentLocale as type AppLocale or undefined
+  // and init as undefined
+  let currentLocale: AppLocale | undefined = undefined;
+
   // get the current locale from router,
-  // and make sure it's a valid language we want to use
-  const currentLocale: Language | undefined = isLanguage(router.locale)
-    ? router.locale
-    : undefined;
+  // and make sure it's a valid language using type guard
+  if (router.locale && isAppLocale(router.locale)) {
+    // router locale is valid app locale
+    // ok to set as current locale
+    currentLocale = router.locale;
+  }
 
   // function that handled language change
-  const handleLanguageChange = (language: Language) => {
+  const handleLanguageChange = (language: AppLocale) => {
     // first check if the selected language is the current locale
     if (currentLocale === language) {
       // nothing to change, languages are the same
@@ -104,7 +95,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = () => {
 
   // function that renders a single language button
   // we give unique key for each button
-  const renderLanguageButton = (language: Language) => {
+  const renderLanguageButton = (language: AppLocale) => {
     // first check if this language is currently selected
     const isSelected = currentLocale === language;
     const buttonLabel = language.toUpperCase();
@@ -141,9 +132,7 @@ const LanguageSelector: React.FC<LanguageSelectorProps> = () => {
     <>
       {shouldRenderSelector && (
         <Stack role="group" sx={stackStyle} aria-label={t("languageSelector")}>
-          {renderLanguageButton(Language.FI)}
-          {renderLanguageButton(Language.SV)}
-          {renderLanguageButton(Language.EN)}
+          {APP_LOCALES.map(renderLanguageButton)}
         </Stack>
       )}
     </>

--- a/src/components/ListFilters.tsx
+++ b/src/components/ListFilters.tsx
@@ -7,6 +7,7 @@ import Router from "next/router";
 import { CollectionData, FacetGroupData } from "interfaces";
 import FormLabel from "components/form/FormLabel";
 import useLinkUtils from "hooks/useLinkUtils";
+import { useTranslation } from "next-i18next";
 
 const ListFilters: React.FC<{ collection: CollectionData }> = ({
   collection
@@ -31,8 +32,13 @@ const FacetSelector: React.FC<{
   facetGroup: FacetGroupData;
 }> = ({ facetGroup }) => {
   const linkUtils = useLinkUtils();
+  const { t } = useTranslation();
 
-  const { label, facets } = facetGroup;
+  const { facets, label: rawLabel } = facetGroup;
+
+  // if facet label is 'Formats', translate it to current locale
+  // note: other facet labels come from backend already translated
+  const label = rawLabel === "Formats" ? t("listFilters.label") : rawLabel;
 
   const activeFacet = facets.find(facet => !!facet.active);
 

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -52,7 +52,7 @@ const Modal: React.FC<ModalProps> = ({
         <div
           sx={{
             backgroundColor: "rgb(0 0 0 / 0.1)",
-            "-webkit-backdrop-filter": "blur(4px)",
+            WebkitBackdropFilter: "blur(4px)",
             backdropFilter: "blur(4px)"
           }}
         ></div>

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -68,7 +68,8 @@ describe("BorrowableBook", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/borrow",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
     const borrowButton = screen.getByRole("button", {
       name: /Borrowing.../i
@@ -120,7 +121,8 @@ describe("OnHoldBook", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/borrow",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
     const borrowButton = screen.getByRole("button", {
       name: /Borrowing.../i
@@ -178,7 +180,8 @@ describe("ReservableBook", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/reserve",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
     const borrowButton = screen.getByRole("button", {
       name: /Reserving.../i
@@ -231,7 +234,8 @@ describe("ReservedBook", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/revoke",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
 
     expect(mockSetBook).toHaveBeenCalledWith(unreservedBook, reservedBook.id);

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -51,7 +51,8 @@ test("borrowing calls correct url with token", async () => {
   expect(mockedFetchBook).toHaveBeenCalledWith(
     "/url",
     "http://test-cm.com/catalogUrl",
-    "user-token"
+    "user-token",
+    "en"
   );
 
   await waitForElementToBeRemoved(() => screen.getByText("Borrowing..."));

--- a/src/components/__tests__/Collection.test.tsx
+++ b/src/components/__tests__/Collection.test.tsx
@@ -40,7 +40,7 @@ test("calls swr to fetch collection", () => {
   });
 
   expect(mockedSWR).toHaveBeenCalledWith(
-    ["/collection", "user-token"],
+    ["/collection", "user-token", "en"],
     fetchCollection
   );
 });

--- a/src/components/__tests__/LanguageSelector.test.tsx
+++ b/src/components/__tests__/LanguageSelector.test.tsx
@@ -1,6 +1,6 @@
 import { mockUseTranslation } from "test-utils/mockUseTranslation";
 import { render, screen, fireEvent } from "test-utils";
-import LanguageSelector, { Language } from "components/LanguageSelector";
+import LanguageSelector from "components/LanguageSelector";
 import React from "react";
 
 // mock the next/router first
@@ -51,9 +51,9 @@ describe("LanguageSelector", () => {
   });
 
   it.each([
-    [Language.FI, "Valitse sivun kieli"],
-    [Language.SV, "Välj sidspråk"],
-    [Language.EN, "Select page language"]
+    ["fi", "Valitse sivun kieli"],
+    ["sv", "Välj sidspråk"],
+    ["en", "Select page language"]
   ])(
     "should show correct aria-label when locale is %s",
     (locale, ariaLabel) => {
@@ -67,7 +67,7 @@ describe("LanguageSelector", () => {
   );
 
   it("should render language buttons", () => {
-    setup(Language.FI);
+    setup("fi");
     const buttons = screen.getAllByRole("button");
 
     // there should be exactly three buttons
@@ -87,10 +87,10 @@ describe("LanguageSelector", () => {
   // define test case table
   // that creates three tests cases for each language
   it.each`
-    locale         | ariaLabels
-    ${Language.FI} | ${["Suomi", "Ruotsi", "Englanti"]}
-    ${Language.EN} | ${["Finnish", "Swedish", "English"]}
-    ${Language.SV} | ${["Finska", "Svenska", "Engelska"]}
+    locale  | ariaLabels
+    ${"fi"} | ${["Suomi", "Ruotsi", "Englanti"]}
+    ${"sv"} | ${["Finska", "Svenska", "Engelska"]}
+    ${"en"} | ${["Finnish", "Swedish", "English"]}
   `(
     "should render correct accessible names for button in $langCode",
     ({ locale, ariaLabels }) => {
@@ -106,7 +106,7 @@ describe("LanguageSelector", () => {
   );
 
   it("should select the current language", () => {
-    setup(Language.SV);
+    setup("sv");
 
     // SV button should be selected
     expect(screen.getByText("FI")).not.toHaveAttribute("aria-current");
@@ -115,18 +115,18 @@ describe("LanguageSelector", () => {
   });
 
   it("should call router.push with correct locale when changing language", () => {
-    const { push } = setup(Language.FI);
+    const { push } = setup("fi");
 
     fireEvent.click(screen.getByText("SV"));
 
     // should call router.push with Swedish
     expect(push).toHaveBeenCalledWith("/test", "/test", {
-      locale: Language.SV
+      locale: "sv"
     });
   });
 
   it("should not call router.push when clicking the current language", () => {
-    const { push } = setup(Language.SV);
+    const { push } = setup("sv");
 
     fireEvent.click(screen.getByText("SV"));
 
@@ -144,7 +144,7 @@ describe("LanguageSelector", () => {
 
   it("should not render selector if router is not ready", () => {
     // setup using unready router
-    setup(Language.FI, false);
+    setup("fi", false);
 
     // should not find language selector
     expect(screen.queryByRole("group")).not.toBeInTheDocument();

--- a/src/components/__tests__/ListFilters.test.tsx
+++ b/src/components/__tests__/ListFilters.test.tsx
@@ -131,7 +131,9 @@ test("renders all facets when present", () => {
     />
   );
 
-  expect(screen.getByRole("combobox", { name: "Formats" })).toBeInTheDocument();
+  expect(
+    screen.getByRole("combobox", { name: "Book format" })
+  ).toBeInTheDocument();
   expect(
     screen.getByRole("combobox", { name: "Availability" })
   ).toBeInTheDocument();
@@ -160,7 +162,7 @@ describe("Format filters", () => {
     setup(<PageTitle>Child</PageTitle>);
     expect(screen.queryByLabelText("Format filters")).toBeFalsy();
     expect(screen.queryByText("All")).toBeFalsy();
-    expect(screen.queryByLabelText("Books")).toBeFalsy();
+    expect(screen.queryByLabelText("ooks")).toBeFalsy();
     expect(screen.queryByLabelText("Audiobooks")).toBeFalsy();
   });
   test("Format filters are visible in PageTitle w/ facets", () => {
@@ -176,7 +178,7 @@ describe("Format filters", () => {
     );
 
     const select = screen.getByRole("combobox", {
-      name: "Formats"
+      name: "Book format"
     }) as HTMLSelectElement;
     // all is selected
     expect(select.value).toBe("eBooks");

--- a/src/components/__tests__/Search.test.tsx
+++ b/src/components/__tests__/Search.test.tsx
@@ -47,7 +47,7 @@ test("fetches search description", async () => {
     }
   });
   expect(mockedSWR).toHaveBeenCalledWith(
-    ["/collection", "user-token"],
+    ["/collection", "user-token", "en"],
     expect.anything()
   );
   expect(mockedSWR).toHaveBeenCalledWith("/search-data-url", expect.anything());

--- a/src/components/bookDetails/Recommendations.tsx
+++ b/src/components/bookDetails/Recommendations.tsx
@@ -12,14 +12,16 @@ import { fetchCollection } from "dataflow/opds1/fetch";
 import useSWR from "swr";
 import useUser from "components/context/UserContext";
 import { useTranslation } from "next-i18next";
+import { useRouter } from "next/router";
 
 const Recommendations: React.FC<{ book: AnyBook }> = ({ book }) => {
   const relatedUrl = book.relatedUrl;
   const { token } = useUser();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   const { data: recommendations, isValidating } = useSWR(
-    relatedUrl ? [relatedUrl, token] : null,
+    relatedUrl ? [relatedUrl, token, locale] : null,
     fetchCollection
   );
 

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -146,7 +146,12 @@ describe("book details page", () => {
     // we make a special mock so we can differentiate the book request
     // and the related collection request
     mockedSWR.mockImplementation(((key: any) => {
-      if (key === "/book-url") {
+      // if key is a string OR
+      // if key is an array and the first item is "/book-url"
+      if (
+        key === "/book-url" ||
+        (Array.isArray(key) && key[0] === "/book-url")
+      ) {
         return makeSwrResponse({
           data: {
             ...fixtures.book,
@@ -154,12 +159,15 @@ describe("book details page", () => {
           }
         });
       }
-      if (key?.[0] === "/related-url") {
+
+      // if key is an array and the first item is "/related-url"
+      if (Array.isArray(key) && key[0] === "/related-url") {
         return makeSwrResponse({
           data: fixtures.recommendations
         });
       }
     }) as any);
+
     setup(<BookDetails />, {
       router: { query: { bookUrl: "/book-url" } }
     });

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -249,7 +249,8 @@ describe("reserved", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/revoke",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
 
     expect(mockSetBook).toHaveBeenCalledWith(unreservedBook, reservedBook.id);
@@ -277,7 +278,8 @@ describe("reserved", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/revoke",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
 
     expect(await screen.findByText("Error: Can't do that")).toBeInTheDocument();
@@ -353,7 +355,8 @@ describe("FulfillableBook", () => {
     expect(mockFetchBook).toHaveBeenCalledWith(
       "/revoke",
       "http://test-cm.com/catalogUrl",
-      "user-token"
+      "user-token",
+      "en"
     );
 
     expect(mockSetBook).toHaveBeenCalledWith(unborrowed, downloadableBook.id);
@@ -515,6 +518,7 @@ describe("FulfillableBook", () => {
     // you fetch the opds entry which should then return you a book with the correct link
     expect(fetchMock).toHaveBeenCalledWith("/indirect", {
       headers: {
+        "Accept-Language": "en",
         Authorization: "user-token",
         "X-Requested-With": "XMLHttpRequest"
       },

--- a/src/components/bookDetails/__tests__/Recommendations.test.tsx
+++ b/src/components/bookDetails/__tests__/Recommendations.test.tsx
@@ -47,7 +47,7 @@ test("fetches the proper url for recommendation collection", () => {
   render(<Recommendations book={fixtures.borrowableBook} />);
   expect(mockedSWR).toHaveBeenCalledTimes(1);
   expect(mockedSWR).toHaveBeenCalledWith(
-    ["http://related-url", "user-token"],
+    ["http://related-url", "user-token", "en"],
     fetchCollection
   );
 });

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -55,8 +55,20 @@ export const BookDetails: React.FC = () => {
   const book = loans?.find(loanedBook => data?.id === loanedBook.id) ?? data;
 
   const subtitle = getSubtitle(book);
-  const { storedBreadcrumbs } = useBreadcrumbContext();
   const { t } = useTranslation();
+
+  // get current breadcrumbs and update function from context
+  const { storedBreadcrumbs, setStoredBreadcrumbs } = useBreadcrumbContext();
+
+  // effect that clears the breadcrumbs whenever book details page is opened.
+  // If the user changes locale in book detail page, the stored breadcrumbs
+  // become outdated. We cannot easily update the breadcrumbs in book detail page,
+  // because they are computed in collection pages on locale change,
+  // so we just clear the breadcrumbs so that wrong language is not used.
+  // Note: this should be only temporary fix for now
+  React.useEffect(() => {
+    setStoredBreadcrumbs([]);
+  }, [setStoredBreadcrumbs]);
 
   if (error) {
     // just throw the error and let it be handled by an error boundary

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -28,16 +28,34 @@ import useBreadcrumbContext from "components/context/BreadcrumbContext";
 import useSWR from "swr";
 import useUser from "components/context/UserContext";
 import { useTranslation } from "next-i18next";
+import useLibraryContext from "components/context/LibraryContext";
 
 export const BookDetails: React.FC = () => {
-  const { query } = useRouter();
+  const { locale, query } = useRouter();
+  const { catalogUrl } = useLibraryContext();
   const bookUrl = extractParam(query, "bookUrl");
-  const { data, error } = useSWR(bookUrl ?? null, fetchBook);
+
+  // define cache key (unique) for SWR based on bookUrl and locale.
+  // note: if bookUrl or locale is missing we don't fetch anything
+  const key = bookUrl && locale ? [bookUrl, locale] : null;
+
+  // define the fetcher function for SWR.
+  // Token is undefined here because authentication
+  // is not required the fetch normal book data from backend
+  const fetcher = () => fetchBook(bookUrl, catalogUrl, undefined, locale);
+
+  // SWR calls fetchBook when it needs new data
+  // data is the fetched book and error is any happened error during fetching
+  const { data, error } = useSWR(key, fetcher);
+
+  // get user's loaned and reserved books (MyBooks)
   const { loans } = useUser();
-  const { storedBreadcrumbs } = useBreadcrumbContext();
-  // use the loans version if it exists
+  // always use the MyBooks version of the book, if it is available
+  // otherwise, just use the fetched data as the book
   const book = loans?.find(loanedBook => data?.id === loanedBook.id) ?? data;
+
   const subtitle = getSubtitle(book);
+  const { storedBreadcrumbs } = useBreadcrumbContext();
   const { t } = useTranslation();
 
   if (error) {

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -9,6 +9,7 @@ import useSWR from "swr";
 import { BasicTokenAuthType, EkirjastoAuthType } from "types/opds1";
 import { addHours, isBefore } from "date-fns";
 import { fetchEAuthToken, fetchEkirjastoToken } from "auth/ekirjastoFetch";
+import { useRouter } from "next/router";
 
 type Status = "authenticated" | "loading" | "unauthenticated";
 export type UserState = {
@@ -77,10 +78,11 @@ export const UserProvider = ({ children }: UserProviderProps) => {
   );
 
   function useFetchFeed(fetchableUrl: string | null) {
+    const { locale } = useRouter();
     return useSWR(
       // pass null if there are no credentials or shelfUrl to tell SWR not to fetch at all.
       credentials && fetchableUrl
-        ? [fetchableUrl, token, credentials?.methodType]
+        ? [fetchableUrl, token, locale, credentials?.methodType]
         : null,
       fetchLoans,
       {
@@ -241,8 +243,8 @@ export default function useUser() {
 
 // we only need the books out of a collection for loans,
 // so this is a utility to extract those.
-async function fetchLoans(url: string, token: string) {
-  const collection = await fetchCollection(url, token);
+async function fetchLoans(url: string, token: string, locale: string) {
+  const collection = await fetchCollection(url, token, locale);
   return collection.books;
 }
 

--- a/src/components/context/__tests__/UserContext.test.tsx
+++ b/src/components/context/__tests__/UserContext.test.tsx
@@ -38,7 +38,8 @@ beforeEach(() => {
   window.location.hash = "";
   useRouterSpy.mockReturnValue({
     query: {},
-    replace: jest.fn()
+    replace: jest.fn(),
+    locale: "en"
   } as any);
 });
 
@@ -47,7 +48,7 @@ test("fetches loans when credentials are present", async () => {
   renderUserContext();
 
   expect(mockSWR).toHaveBeenCalledWith(
-    ["/shelf-url", "some-token", "http://opds-spec.org/auth/basic"],
+    ["/shelf-url", "some-token", "en", "http://opds-spec.org/auth/basic"],
     expect.anything(),
     expect.anything()
   );
@@ -85,6 +86,7 @@ test("extracts clever tokens from the url", () => {
     [
       "/shelf-url",
       "Bearer fry6H3",
+      "en",
       "http://librarysimplified.org/authtype/OAuth-with-intermediary"
     ],
     expect.anything(),
@@ -109,7 +111,8 @@ test("extracts SAML tokens from the url", () => {
   window.location = url as any;
   useRouterSpy.mockReturnValue({
     replace: mockReplace,
-    query: { access_token: "saml-token" }
+    query: { access_token: "saml-token" },
+    locale: "en"
   } as any);
   renderUserContext();
 
@@ -129,6 +132,7 @@ test("extracts SAML tokens from the url", () => {
     [
       "/shelf-url",
       "Bearer saml-token",
+      "en",
       "http://librarysimplified.org/authtype/SAML-2.0"
     ],
     expect.anything(),
@@ -159,7 +163,7 @@ test("sign out clears cookies and data", async () => {
 
   // make sure fetch was called and you have the right data
   expect(mockSWR).toHaveBeenCalledWith(
-    ["/shelf-url", "some-token", "http://opds-spec.org/auth/basic"],
+    ["/shelf-url", "some-token", "en", "http://opds-spec.org/auth/basic"],
     expect.anything(),
     expect.anything()
   );
@@ -205,7 +209,7 @@ test("sign in sets cookie", async () => {
   );
 
   expect(mockSWR).toHaveBeenCalledWith(
-    ["/shelf-url", "a-token", "type"],
+    ["/shelf-url", "a-token", "en", "type"],
     expect.anything(),
     expect.anything()
   );

--- a/src/computeBreadcrumbs.tsx
+++ b/src/computeBreadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { CollectionData, LinkData } from "interfaces";
+import { AppLocale, normaliseLocale } from "../appLocales";
 
 // Custom URL comparator to ignore trailing slashes.
 const urlComparator = (
@@ -14,7 +15,10 @@ const urlComparator = (
   return !!(url1 && url2) && url1 === url2;
 };
 
-const computeBreadcrumbs = (collection?: CollectionData): LinkData[] => {
+const computeBreadcrumbs = (
+  collection?: CollectionData,
+  locale?: string
+): LinkData[] => {
   let links: LinkData[] = [];
 
   if (
@@ -39,7 +43,8 @@ const computeBreadcrumbs = (collection?: CollectionData): LinkData[] => {
     links = hierarchyComputeBreadcrumbs(collection, urlComparator);
   }
 
-  return links;
+  const appLocale = normaliseLocale(locale);
+  return localiseLinkTexts(links, appLocale);
 };
 
 export default computeBreadcrumbs;
@@ -92,4 +97,56 @@ export function hierarchyComputeBreadcrumbs(
   });
 
   return links;
+}
+
+// define localisation map for FI, SV and EN locales
+// The keys are collection entrypoints.
+// this map should be used until the breadcrumbs computing is refactored
+const localisationMap: { [key: string]: { [key: string]: string } } = {
+  fi: {
+    All: "E-kirjat ja äänikirjat",
+    Book: "E-kirjat",
+    Audio: "Äänikirjat"
+  },
+  sv: {
+    All: "E-böcker och ljudböcker",
+    Book: "E-böcker",
+    Audio: "Ljudböcker"
+  },
+  en: {
+    All: "E-books and Audiobooks",
+    Book: "E-books",
+    Audio: "Audiobooks"
+  }
+};
+
+// helper function to localise link texts for current locale.
+// Changes the English entrypoint parameters from backend
+// to more descriptive English and gives translations
+// for Finnish and Swedish
+function localiseLinkTexts(
+  links: LinkData[],
+  appLocale: AppLocale | undefined
+): LinkData[] {
+  // just to be safe!
+  if (!appLocale) return links;
+
+  // create a new list for the localised links
+  return links.map(link => {
+    // first check if the link has text property
+    if (link.text) {
+      // then try to get the localised text from the map
+      const localisedText = localisationMap[appLocale][link.text];
+
+      // if there is a match and the localised text exists
+      // return that version of text with this link
+      if (localisedText) {
+        return { ...link, text: localisedText };
+      }
+    }
+
+    // if no link text or matching localisation is found
+    // just return the original link without modifications
+    return link;
+  });
 }

--- a/src/dataflow/__tests__/getLibraryData.test.tsx
+++ b/src/dataflow/__tests__/getLibraryData.test.tsx
@@ -20,7 +20,7 @@ describe("fetching catalog", () => {
     expect(fetchMock).toHaveBeenCalledWith("some-url", {
       headers: {
         "X-Requested-With": "XMLHttpRequest",
-        "Accept-Language": "*"
+        "Accept-Language": "fi"
       },
       method: "GET"
     });

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -94,9 +94,10 @@ export async function fetchEntry(
  */
 export async function fetchCollection(
   url: string,
-  token?: string
+  token?: string,
+  locale?: string
 ): Promise<CollectionData> {
-  const feed = await fetchFeed(url, token);
+  const feed = await fetchFeed(url, token, locale);
   const collection = feedToCollection(feed, url);
   return collection;
 }

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -108,9 +108,10 @@ export async function fetchCollection(
 export async function fetchBook(
   url: string,
   catalogUrl: string,
-  token?: string
+  token?: string,
+  locale?: string
 ): Promise<AnyBook> {
-  const entry = await fetchEntry(url, token);
+  const entry = await fetchEntry(url, token, locale);
   const book = entryToBook(entry, catalogUrl);
   return book;
 }

--- a/src/dataflow/opds1/fetch.ts
+++ b/src/dataflow/opds1/fetch.ts
@@ -7,6 +7,7 @@ import { AnyBook, CollectionData, OPDS1 } from "interfaces";
 import { entryToBook, feedToCollection } from "dataflow/opds1/parse";
 import fetchWithHeaders from "dataflow/fetch";
 import parseSearchData from "dataflow/opds1/parseSearchData";
+import { normaliseLocale } from "../../../appLocales";
 
 const parser = new OPDSParser();
 /**
@@ -47,17 +48,18 @@ export async function fetchOPDS(
  */
 export async function fetchFeed(
   url: string,
-  token?: string
+  token?: string,
+  locale?: string
 ): Promise<OPDSFeed> {
-  const result = await fetchOPDS(url, token, {
-    // Explicitly accept all languages when fetching feeds. Otherwise, the browser will send an
-    // Accept-Language header for its current language, which causes books in other languages to
-    // be filtered out of search results.
-    "Accept-Language": "*"
-  });
+  // define additional headers, including Accept-Language based on locale
+  const additionalHeaders = getAdditionalHeaders(locale);
+
+  const result = await fetchOPDS(url, token, additionalHeaders);
+
   if (result instanceof OPDSFeed) {
     return result;
   }
+
   throw new ApplicationError({
     title: "OPDS Error",
     detail: `Network response was expected to be an OPDS 1.x Feed, but was not parseable as such. Url: ${url}`
@@ -69,12 +71,18 @@ export async function fetchFeed(
  */
 export async function fetchEntry(
   url: string,
-  token?: string
+  token?: string,
+  locale?: string
 ): Promise<OPDSEntry> {
-  const result = await fetchOPDS(url, token);
+  // define additional headers, including Accept-Language based on locale
+  const additionalHeaders = getAdditionalHeaders(locale);
+
+  const result = await fetchOPDS(url, token, additionalHeaders);
+
   if (result instanceof OPDSEntry) {
     return result;
   }
+
   throw new ApplicationError({
     title: "OPDS Error",
     detail: `Network response was expected to be an OPDS 1.x Entry, but was not parseable as such. Url: ${url}`
@@ -146,4 +154,21 @@ export async function fetchSearchData(url: string) {
   const text = await response.text();
   const data = await parseSearchData(text, url);
   return data;
+}
+
+// function for defining the additional headers
+// for OPDS requests such as fethcFeed and fetchEntry.
+// Returns a header object
+//   - Accept-Language header:
+//     * is used to forward the user's preferred language
+//     * server should return the content in this language
+function getAdditionalHeaders(locale?: string) {
+  // define a language string
+  // if the locale given as parameter is valid, use that
+  // otherwise just use the app default locale
+  const language: string = normaliseLocale(locale);
+
+  return {
+    "Accept-Language": language
+  };
 }

--- a/src/dataflow/withAppProps.ts
+++ b/src/dataflow/withAppProps.ts
@@ -10,6 +10,7 @@ import extractParam from "dataflow/utils";
 import { ParsedUrlQuery } from "querystring";
 import track from "analytics/track";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { APP_DEFAULT_LOCALE } from "../../appLocales";
 
 export type AppProps = {
   library?: LibraryData;
@@ -45,7 +46,7 @@ export default function withAppProps(
       // define the current locale.
       // Use the locale from context,
       // or if is missing, use app's default locale
-      const currentLocale = ctx.locale ?? "fi";
+      const currentLocale = ctx.locale ?? APP_DEFAULT_LOCALE;
 
       // fetch translations for the current locale from the server,
       // translationNamespaces is used for finding translation keys

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -5,6 +5,7 @@ import useLibraryContext from "components/context/LibraryContext";
 import useError from "hooks/useError";
 import useLogin from "auth/useLogin";
 import { useTranslation } from "next-i18next";
+import { useRouter } from "next/router";
 
 export default function useBorrow(isBorrow: boolean) {
   const { catalogUrl } = useLibraryContext();
@@ -14,6 +15,7 @@ export default function useBorrow(isBorrow: boolean) {
   const [isLoading, setLoading] = React.useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
   const { t } = useTranslation();
+  const { locale } = useRouter();
 
   const loadingText = isBorrow
     ? t("useBorrow.borrowing")
@@ -31,7 +33,7 @@ export default function useBorrow(isBorrow: boolean) {
     }
     setLoading(true);
     try {
-      const book = await fetchBook(url, catalogUrl, token);
+      const book = await fetchBook(url, catalogUrl, token, locale);
       setBook(book);
     } catch (e) {
       handleError(e);

--- a/src/hooks/useCollection.ts
+++ b/src/hooks/useCollection.ts
@@ -12,7 +12,7 @@ import { cacheCollectionBooks } from "utils/cache";
 export default function useCollection() {
   const { catalogUrl } = useLibraryContext();
   const { token } = useUser();
-  const { query, pathname } = useRouter();
+  const { locale, query, pathname } = useRouter();
   const collectionUrlParam = extractParam(query, "collectionUrl") ?? null;
   // use catalog url if you're at home
   const isLibraryHome = pathname === "/[library]";
@@ -21,7 +21,7 @@ export default function useCollection() {
   const { data: collection, error, isValidating } = useSWR<
     CollectionData,
     Error | ApplicationError
-  >(collectionUrl ? [collectionUrl, token] : null, fetchCollection);
+  >(collectionUrl ? [collectionUrl, token, locale] : null, fetchCollection);
 
   // make sure unidentified errors are wrapped in an ApplicationError
   let applicationError: ApplicationError | undefined = undefined;

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import ErrorComponent from "../components/Error";
 import { GetStaticProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { APP_DEFAULT_LOCALE } from "../../appLocales";
 
 export default function NotFoundPage() {
   return (
@@ -16,7 +17,7 @@ export default function NotFoundPage() {
 }
 
 export const getStaticProps: GetStaticProps = async ({ locale }) => {
-  const currentLocale = locale ?? "fi";
+  const currentLocale = locale ?? APP_DEFAULT_LOCALE;
   const translationNamespaces = ["translations"];
 
   const translations = await serverSideTranslations(

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,6 +6,7 @@ import OpenEbooksLandingPage, {
 import MultiLibraryHome from "components/MultiLibraryHome";
 import { GetStaticProps } from "next";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { APP_DEFAULT_LOCALE } from "../../appLocales";
 
 const HomePage = IS_OPEN_EBOOKS ? OpenEbooksLandingPage : MultiLibraryHome;
 
@@ -14,7 +15,7 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => {
     return landingPageStaticProps({ locale });
   }
 
-  const currentLocale = locale ?? "fi";
+  const currentLocale = locale ?? APP_DEFAULT_LOCALE;
   const translationNamespaces = ["translations"];
 
   const translations = await serverSideTranslations(

--- a/src/test-utils/mockNextRouter.tsx
+++ b/src/test-utils/mockNextRouter.tsx
@@ -6,6 +6,7 @@ import Router from "next/router";
 import { RouterContext } from "next/dist/shared/lib/router-context.shared-runtime";
 import { NextRouter } from "next/router";
 import { libraryData } from "test-utils/fixtures";
+import { APP_DEFAULT_LOCALE_FOR_TESTING } from "../../appLocales";
 
 /**
  * Mock for the next/Router import.
@@ -37,6 +38,7 @@ export const MockNextRouterContextProvider: React.FC<{
     isFallback = false,
     isLocaleDomain = false,
     isPreview = false,
+    locale = APP_DEFAULT_LOCALE_FOR_TESTING,
     events = {
       on: () => null,
       off: () => null,
@@ -61,6 +63,7 @@ export const MockNextRouterContextProvider: React.FC<{
         isFallback,
         isLocaleDomain,
         isPreview,
+        locale,
         events
       }}
     >

--- a/src/test-utils/mockUseTranslation.ts
+++ b/src/test-utils/mockUseTranslation.ts
@@ -1,3 +1,4 @@
+import { APP_DEFAULT_LOCALE_FOR_TESTING } from "../../appLocales";
 import enTranslations from "../../public/locales/en/translations.json";
 import fiTranslations from "../../public/locales/fi/translations.json";
 import svTranslations from "../../public/locales/sv/translations.json";
@@ -13,7 +14,7 @@ const translations: Record<string, Record<string, string>> = {
 // set default language for tests as English
 // (we usually test with source code language)
 // note: actual app default is Finnish
-let currentLanguage = "en";
+let currentLanguage = APP_DEFAULT_LOCALE_FOR_TESTING;
 
 // helper function that replaces placeholders
 // in a translation strings with actual values.

--- a/src/utils/__tests__/fulfill.test.ts
+++ b/src/utils/__tests__/fulfill.test.ts
@@ -32,7 +32,11 @@ describe("fulfill", () => {
           /* eslint-enable camelcase */
         );
 
-        const location = await fulfillment.getLocation("catalog-url", "token");
+        const location = await fulfillment.getLocation(
+          "catalog-url",
+          "token",
+          "en"
+        );
 
         expect(fetchMock).toHaveBeenCalledWith("link-url", {
           headers: {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -163,17 +163,28 @@ function isSupported(
  */
 type GetLocationWithIndirection = (
   catalogUrl: string,
-  token?: string
+  token?: string,
+  locale?: string | undefined
 ) => Promise<AuthorizedLocation>;
 
 const constructGetLocation = (
   indirectionType: OPDS1.IndirectAcquisitionType | undefined,
   contentType: OPDS1.AnyBookMediaType,
   url: string
-): GetLocationWithIndirection => async (catalogUrl: string, token?: string) => {
+): GetLocationWithIndirection => async (
+  catalogUrl: string,
+  token?: string,
+  locale?: string | undefined
+) => {
   switch (indirectionType) {
     case OPDS1.OPDSEntryMediaType:
-      return await resolveOpdsEntry(url, catalogUrl, token, contentType);
+      return await resolveOpdsEntry(
+        url,
+        catalogUrl,
+        token,
+        contentType,
+        locale
+      );
 
     case OPDS1.BearerTokenMediaType:
       return await resolveBearerToken(url, token);
@@ -197,9 +208,15 @@ async function resolveOpdsEntry(
   url: string,
   catalogUrl: string,
   token: string | undefined,
-  contentType: OPDS1.AnyBookMediaType
+  contentType: OPDS1.AnyBookMediaType,
+  locale?: string | undefined
 ): Promise<AuthorizedLocation> {
-  const book = (await fetchBook(url, catalogUrl, token)) as FulfillableBook;
+  const book = (await fetchBook(
+    url,
+    catalogUrl,
+    token,
+    locale
+  )) as FulfillableBook;
   if (!book) {
     throw new ApplicationError({
       title: "Fetch Error",


### PR DESCRIPTION
## Description

- This pull request adds more language support to the E-kirjasto web app by requesting data from the backend based on to the app's selected language
  - we want to show content based on the user's language preference
  - for example, users will see book details with their selected language
  - [EKIRJASTO-783](https://jira.it.helsinki.fi/browse/EKIRJASTO-783), [EKIRJASTO-796](https://jira.it.helsinki.fi/browse/EKIRJASTO-796), [EKIRJASTO-806](https://jira.it.helsinki.fi/browse/EKIRJASTO-806)

- Data-fetching functions were updated to handle locale
  - backend supports Finnish, Swedish and English languages, so the web app was updated to pass the correct locale when fetching book details or collection from the backend
    - note: some minor localisations were not available from the backend, so those strings were translated directly in the app 
  - `fetchFeed` and `fetchEntry` functions now take a locale as parameter and set the Accept-Language header

- New file `appLocales.ts` was created to contain all the locale definitions and helper functions needed when handling locales


## How can this be tested?

- review the file `appLocales.ts`
- review the file `src/dataflow/opds1/fetch.ts`
- test the application and switch languages
  - check that the content updates accordingly and immediately shows the correct language
  - check for example
    - book details page metadata
    - collection book lists and lanes
    - My Books list
    - breadcrumbs
    - collection filters
    - error messages (originating from backend, for example loan limit)

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [x] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
