### PR TITLE
Ekir 801 prevent magazines display to unauthorized users

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -1,4 +1,5 @@
 {
+  "auth.unauthorizedMessage": "You need to be signed in to view this page.",
   "book.borrowable": "Available: {{availableCopies}} / {{totalCopies}}",
   "book.differenceInDays": "{{differenceInDays}} days",
   "book.differenceInHours": "{{differenceInHours}} hours",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -1,4 +1,5 @@
 {
+  "auth.unauthorizedMessage": "Kirjaudu sisään nähdäksesi tämän sivun",
   "book.borrowable": "Saatavissa: {{availableCopies}} / {{totalCopies}}",
   "book.differenceInDays": "{{differenceInDays}} päivää",
   "book.differenceInHours": "{{differenceInHours}} tuntia",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -1,4 +1,5 @@
 {
+  "auth.unauthorizedMessage": "Du måste logga in för att se den här sidan",
   "book.borrowable": "Tillgänglig: {{availableCopies}} / {{totalCopies}}",
   "book.differenceInDays": "{{differenceInDays}} dagar",
   "book.differenceInHours": "{{differenceInHours}} timmar",

--- a/src/auth/AuthProtectedRoute.tsx
+++ b/src/auth/AuthProtectedRoute.tsx
@@ -4,6 +4,7 @@ import { jsx } from "theme-ui";
 import useUser from "components/context/UserContext";
 import { PageLoader } from "components/LoadingIndicator";
 import React from "react";
+import { useTranslation } from "next-i18next";
 
 /**
  * This will show a message if the user tries to access a route they are not permitted to see.
@@ -27,6 +28,8 @@ const AuthProtectedRoute = ({ children }: Props) => {
 export default AuthProtectedRoute;
 
 const Unauthorized = () => {
+  const { t } = useTranslation();
+
   return (
     <div
       sx={{
@@ -37,7 +40,7 @@ const Unauthorized = () => {
         flexDirection: "column"
       }}
     >
-      <h4>You need to be signed in to view this page.</h4>
+      <h4>{t("auth.unauthorizedMessage")}</h4>
     </div>
   );
 };

--- a/src/auth/AuthProtectedRoute.tsx
+++ b/src/auth/AuthProtectedRoute.tsx
@@ -1,28 +1,19 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
 import { jsx } from "theme-ui";
-import useLogin from "auth/useLogin";
 import useUser from "components/context/UserContext";
 import { PageLoader } from "components/LoadingIndicator";
 import React from "react";
 
 /**
- * This will show a message and redirect the user to the login
- * page if they try to access a route they are not permitted to see.
+ * This will show a message if the user tries to access a route they are not permitted to see.
  */
 
 interface Props {
   children: React.ReactNode;
 }
 const AuthProtectedRoute = ({ children }: Props) => {
-  const { isLoading, isAuthenticated, token, error } = useUser();
-  const { initLogin } = useLogin();
-
-  React.useEffect(() => {
-    if ((!token || error) && !isLoading) {
-      initLogin();
-    }
-  }, [initLogin, token, error, isLoading]);
+  const { isLoading, isAuthenticated } = useUser();
 
   if (isAuthenticated) {
     return <>{children}</>;

--- a/src/components/__tests__/magazines.test.tsx
+++ b/src/components/__tests__/magazines.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { render, fixtures } from "test-utils";
-import MagazinesFixedPage from "../index";
+import MagazinesFixedPage from "pages/[library]/magazines/index";
 
 test("unauthenticated user sees unauthorized message", () => {
   const utils = render(<MagazinesFixedPage library={fixtures.libraryData} />);

--- a/src/pages/[library]/magazines/__tests__/magazines.test.tsx
+++ b/src/pages/[library]/magazines/__tests__/magazines.test.tsx
@@ -1,0 +1,11 @@
+import * as React from "react";
+import { render, fixtures } from "test-utils";
+import MagazinesFixedPage from "../index";
+
+test("unauthenticated user sees unauthorized message", () => {
+  const utils = render(<MagazinesFixedPage library={fixtures.libraryData} />);
+  // Check that the unauthorized message is shown
+  expect(
+    utils.queryByText("You need to be signed in to view this page.")
+  ).toBeInTheDocument();
+});

--- a/src/pages/[library]/magazines/index.tsx
+++ b/src/pages/[library]/magazines/index.tsx
@@ -18,6 +18,7 @@ import Head from "next/head";
 import BreadcrumbBar from "components/BreadcrumbBar";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 import { useTranslation } from "next-i18next";
+import AuthProtectedRoute from "auth/AuthProtectedRoute";
 
 const MagazinesFixedContent: React.FC = () => {
   const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
@@ -158,7 +159,9 @@ const MagazinesFixedPage: NextPage<AppProps> = ({ library, error }) => {
         <BreadcrumbBar
           currentLocation={t("magazines.breadcrumbForMagazines")}
         />
-        <MagazinesFixedContent />
+        <AuthProtectedRoute>
+          <MagazinesFixedContent />
+        </AuthProtectedRoute>
       </>
     </LayoutPage>
   );


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
Adds `AuthProtectedRoute` to `MagazinesFixedContent` to prevent unauthorized users from viewing actual magazines.
In addition, the automatically initiated login is removed from `AuthProtectedRoute` and only shows a message of required login to view the content.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->
Make sure you remove all cookies and cache from your testing browser to simulate what the user experiences on their first attempt.

1. Test: logged out
Don't log in. Go to `http://localhost:3000/ekirjasto/magazines`. You should see the unauthorized message. (Same when navigating now to `http://localhost:3000/ekirjasto/loans`.)

2. Test: logged in
Log in. Go to `http://localhost:3000/ekirjasto/magazines`. You should see the magazines content and be able to read a magazine.

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
