### PR TITLE
EKIRJASTO-708 Adjust logout

### DIFF
--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -25,14 +25,17 @@ export default function Logout(): React.ReactElement {
 
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
-  const supportedAuthMethods = authMethods.filter(m =>
-    isSupportedAuthType(m.type)
+  const supportedAuthMethods = React.useMemo(
+    () => authMethods.filter(m => isSupportedAuthType(m.type)),
+    [authMethods]
   );
 
   // Get the ekirjasto auth method
-  const method = authMethods.find(
-    method => method.type === EKIRJASTO_AUTH_TYPE
-  )!;
+  const method = React.useMemo(
+    () =>
+      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)!,
+    [supportedAuthMethods]
+  );
 
   // Get link for logout
   const authenticationLogoutHref = method.links?.find(
@@ -62,8 +65,10 @@ export default function Logout(): React.ReactElement {
   };
 
   React.useEffect(() => {
-    fetchEkirjastoToken();
-  });
+    if (token && method) {
+      fetchEkirjastoToken();
+    }
+  }, [token, method]);
 
   React.useEffect(() => {
     if (ekirjastoToken && authenticationLogoutHref) {
@@ -75,8 +80,8 @@ export default function Logout(): React.ReactElement {
         secure: true
       });
 
-      window.location.href = urlWithRedirect;
       signOut();
+      window.location.href = urlWithRedirect;
     }
   }, [
     token,
@@ -86,7 +91,13 @@ export default function Logout(): React.ReactElement {
     ekirjastoToken
   ]);
 
+  // If there is no supported methods
   if (supportedAuthMethods.length === 0) {
+    return <NoAuth />;
+  }
+
+  // If there is no login methods
+  if (!method) {
     return <NoAuth />;
   }
 

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -35,9 +35,9 @@ export default function Logout(): React.ReactElement {
   );
 
   // Get link for logout
-  const authenticationLogoutHref = method
-    ? method.links?.find(link => link.rel === "logout")?.href
-    : undefined;
+  const authenticationLogoutHref = method ? method.links?.find(
+    link => link.rel === "logout"
+  )?.href : undefined;
 
   // Add the redirect link
   const urlWithRedirect =
@@ -48,13 +48,13 @@ export default function Logout(): React.ReactElement {
       : undefined;
 
   // Get the url for the token
-  const ekirjastoTokenUrl = method
-    ? method.links?.find(link => link.rel === "ekirjasto_token")?.href
-    : undefined;
+  const ekirjastoTokenUrl = method ? method.links?.find(
+    link => link.rel === "ekirjasto_token"
+  )?.href : undefined;
 
   const fetchEkirjastoToken = async () => {
     try {
-      //If we have both token and the ekirjastoToken url, fetch the token
+      //If we have both token and the ekirjastoToken url, fetch the ekirjasto token
       if (token && ekirjastoTokenUrl) {
         // Fetch the ekirjasto token
         const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -100,7 +100,10 @@ export default function Logout(): React.ReactElement {
     signOut,
     authenticationLogoutHref,
     urlWithRedirect,
-    ekirjastoToken
+    ekirjastoToken,
+    circulationTokenRefreshUrl,
+    ekirjastoTokenUrl,
+    getEkirjastoToken
   ]);
 
   // If there is no supported methods

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -35,9 +35,9 @@ export default function Logout(): React.ReactElement {
   );
 
   // Get link for logout
-  const authenticationLogoutHref = method ? method.links?.find(
-    link => link.rel === "logout"
-  )?.href : undefined;
+  const authenticationLogoutHref = method
+    ? method.links?.find(link => link.rel === "logout")?.href
+    : undefined;
 
   // Add the redirect link
   const urlWithRedirect =
@@ -48,9 +48,9 @@ export default function Logout(): React.ReactElement {
       : undefined;
 
   // Get the url for the token
-  const ekirjastoTokenUrl = method ? method.links?.find(
-    link => link.rel === "ekirjasto_token"
-  )?.href : undefined;
+  const ekirjastoTokenUrl = method
+    ? method.links?.find(link => link.rel === "ekirjasto_token")?.href
+    : undefined;
 
   const fetchEkirjastoToken = async () => {
     try {

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -63,7 +63,7 @@ export default function Logout(): React.ReactElement {
       if (token && ekirjastoTokenUrl) {
         // Fetch the ekirjasto token
         const fetchedToken = await getEkirjastoToken(
-          token!,
+          token,
           ekirjastoTokenUrl,
           circulationTokenRefreshUrl
         );

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -80,7 +80,13 @@ export default function Logout(): React.ReactElement {
     if (token && method) {
       fetchEkirjastoToken();
     }
-  }, [token, method]);
+  }, [
+    token,
+    method,
+    ekirjastoTokenUrl,
+    circulationTokenRefreshUrl,
+    getEkirjastoToken
+  ]);
 
   React.useEffect(() => {
     if (ekirjastoToken && urlWithRedirect) {
@@ -95,16 +101,7 @@ export default function Logout(): React.ReactElement {
       signOut();
       window.location.href = urlWithRedirect;
     }
-  }, [
-    token,
-    signOut,
-    authenticationLogoutHref,
-    urlWithRedirect,
-    ekirjastoToken,
-    circulationTokenRefreshUrl,
-    ekirjastoTokenUrl,
-    getEkirjastoToken
-  ]);
+  }, [signOut, urlWithRedirect, ekirjastoToken]);
 
   // If there is no supported methods
   if (supportedAuthMethods.length === 0) {

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -25,35 +25,43 @@ export default function Logout(): React.ReactElement {
 
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
-  const supportedAuthMethods = 
-      authMethods.filter(m => isSupportedAuthType(m.type));
+  const supportedAuthMethods = authMethods.filter(m =>
+    isSupportedAuthType(m.type)
+  );
 
   // Get the ekirjasto auth method
-  const method = 
-      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE);
+  const method = supportedAuthMethods.find(
+    method => method.type === EKIRJASTO_AUTH_TYPE
+  );
 
   // Get link for logout
-  const authenticationLogoutHref = method!.links?.find(
+  const authenticationLogoutHref = method ? method.links?.find(
     link => link.rel === "logout"
-  )?.href;
+  )?.href : undefined;
 
   // Add the redirect link
-  const urlWithRedirect = `${authenticationLogoutHref}&redirect_uri=${encodeURIComponent(
-    logoutRedirectUrl
-  )}`;
+  const urlWithRedirect =
+    authenticationLogoutHref && logoutRedirectUrl
+      ? `${authenticationLogoutHref}&redirect_uri=${encodeURIComponent(
+          logoutRedirectUrl
+        )}`
+      : undefined;
 
   // Get the url for the token
-      const ekirjastoTokenUrl = method!.links?.find(
-        link => link.rel === "ekirjasto_token"
-      )?.href;
+  const ekirjastoTokenUrl = method ? method.links?.find(
+    link => link.rel === "ekirjasto_token"
+  )?.href : undefined;
 
   const fetchEkirjastoToken = async () => {
     try {
-      // Fetch the ekirjasto token
-      const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
+      //If we have both token and the ekirjastoToken url, fetch the token
+      if (token && ekirjastoTokenUrl) {
+        // Fetch the ekirjasto token
+        const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
 
-      // Set the fetched token
-      setEkirjastoToken(fetchedToken);
+        // Set the fetched token
+        setEkirjastoToken(fetchedToken);
+      }
     } catch (error) {
       // If the token fetch fails, it is most likely due to 401,
       // In which case, refresh happens elsewhere
@@ -67,7 +75,7 @@ export default function Logout(): React.ReactElement {
   }, [token, method]);
 
   React.useEffect(() => {
-    if (ekirjastoToken && authenticationLogoutHref) {
+    if (ekirjastoToken && urlWithRedirect) {
       // Set the session cookie
       Cookie.set(LOGOUT_COOKIE_PARAM, ekirjastoToken, {
         path: "/",

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -81,7 +81,7 @@ export default function Logout(): React.ReactElement {
     if (token && method) {
       fetchEkirjastoToken();
     }
-  }, [token, method]);
+  }, [token, method, fetchEkirjastoToken]);
 
   React.useEffect(() => {
     if (ekirjastoToken && urlWithRedirect) {

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -25,17 +25,12 @@ export default function Logout(): React.ReactElement {
 
   // AppAuthMethod[] shouldn't be populated with unsupported auth methods from auth document,
   // but we filter out any unsupported methods just in case.
-  const supportedAuthMethods = React.useMemo(
-    () => authMethods.filter(m => isSupportedAuthType(m.type)),
-    [authMethods]
-  );
+  const supportedAuthMethods = 
+      authMethods.filter(m => isSupportedAuthType(m.type));
 
   // Get the ekirjasto auth method
-  const method = React.useMemo(
-    () =>
-      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE),
-    [supportedAuthMethods]
-  );
+  const method = 
+      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE);
 
   // Get link for logout
   const authenticationLogoutHref = method!.links?.find(
@@ -47,12 +42,14 @@ export default function Logout(): React.ReactElement {
     logoutRedirectUrl
   )}`;
 
-  const fetchEkirjastoToken = async () => {
-    try {
-      // Get the url for the token
-      const ekirjastoTokenUrl = method.links?.find(
+  // Get the url for the token
+      const ekirjastoTokenUrl = method!.links?.find(
         link => link.rel === "ekirjasto_token"
       )?.href;
+
+  const fetchEkirjastoToken = async () => {
+    try {
+      console.log("LLAALALALA")
       // Fetch the ekirjasto token
       const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
 
@@ -81,7 +78,7 @@ export default function Logout(): React.ReactElement {
       });
 
       signOut();
-      window.location.href = urlWithRedirect;
+      //window.location.href = urlWithRedirect;
     }
   }, [
     token,

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -57,31 +57,30 @@ export default function Logout(): React.ReactElement {
     ? method.links?.find(link => link.rel === "authenticate")?.href
     : undefined;
 
-  const fetchEkirjastoToken = async () => {
-    try {
-      //If we have both token and the ekirjastoToken url, fetch the ekirjasto token
-      if (token && ekirjastoTokenUrl) {
-        // Fetch the ekirjasto token
-        const fetchedToken = await getEkirjastoToken(
-          token,
-          ekirjastoTokenUrl,
-          circulationTokenRefreshUrl
-        );
-
-        // Set the fetched token
-        setEkirjastoToken(fetchedToken);
-      }
-    } catch (error) {
-      // If the token fetch fails, it is most likely due to 401,
-      // In which case, refresh happens elsewhere
-    }
-  };
-
   React.useEffect(() => {
+    const fetchEkirjastoToken = async () => {
+      try {
+        //If we have both token and the ekirjastoToken url, fetch the ekirjasto token
+        if (token && ekirjastoTokenUrl) {
+          // Fetch the ekirjasto token
+          const fetchedToken = await getEkirjastoToken(
+            token,
+            ekirjastoTokenUrl,
+            circulationTokenRefreshUrl
+          );
+
+          // Set the fetched token
+          setEkirjastoToken(fetchedToken);
+        }
+      } catch (error) {
+        // If the token fetch fails, it is most likely due to 401,
+        // In which case, refresh happens elsewhere
+      }
+    };
     if (token && method) {
       fetchEkirjastoToken();
     }
-  }, [token, method, fetchEkirjastoToken]);
+  }, [token, method]);
 
   React.useEffect(() => {
     if (ekirjastoToken && urlWithRedirect) {

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -35,9 +35,9 @@ export default function Logout(): React.ReactElement {
   );
 
   // Get link for logout
-  const authenticationLogoutHref = method ? method.links?.find(
-    link => link.rel === "logout"
-  )?.href : undefined;
+  const authenticationLogoutHref = method
+    ? method.links?.find(link => link.rel === "logout")?.href
+    : undefined;
 
   // Add the redirect link
   const urlWithRedirect =
@@ -48,16 +48,25 @@ export default function Logout(): React.ReactElement {
       : undefined;
 
   // Get the url for the token
-  const ekirjastoTokenUrl = method ? method.links?.find(
-    link => link.rel === "ekirjasto_token"
-  )?.href : undefined;
+  const ekirjastoTokenUrl = method
+    ? method.links?.find(link => link.rel === "ekirjasto_token")?.href
+    : undefined;
+
+  // Get the url for circulation token refresh
+  const circulationTokenRefreshUrl = method
+    ? method.links?.find(link => link.rel === "authenticate")?.href
+    : undefined;
 
   const fetchEkirjastoToken = async () => {
     try {
       //If we have both token and the ekirjastoToken url, fetch the ekirjasto token
       if (token && ekirjastoTokenUrl) {
         // Fetch the ekirjasto token
-        const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
+        const fetchedToken = await getEkirjastoToken(
+          token!,
+          ekirjastoTokenUrl,
+          circulationTokenRefreshUrl
+        );
 
         // Set the fetched token
         setEkirjastoToken(fetchedToken);

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -33,12 +33,12 @@ export default function Logout(): React.ReactElement {
   // Get the ekirjasto auth method
   const method = React.useMemo(
     () =>
-      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE)!,
+      supportedAuthMethods.find(method => method.type === EKIRJASTO_AUTH_TYPE),
     [supportedAuthMethods]
   );
 
   // Get link for logout
-  const authenticationLogoutHref = method.links?.find(
+  const authenticationLogoutHref = method!.links?.find(
     link => link.rel === "logout"
   )?.href;
 
@@ -96,7 +96,7 @@ export default function Logout(): React.ReactElement {
     return <NoAuth />;
   }
 
-  // If there is no login methods
+  // If there is no ekirjasto method
   if (!method) {
     return <NoAuth />;
   }

--- a/src/auth/Logout.tsx
+++ b/src/auth/Logout.tsx
@@ -49,7 +49,6 @@ export default function Logout(): React.ReactElement {
 
   const fetchEkirjastoToken = async () => {
     try {
-      console.log("LLAALALALA")
       // Fetch the ekirjasto token
       const fetchedToken = await getEkirjastoToken(token!, ekirjastoTokenUrl);
 
@@ -78,7 +77,7 @@ export default function Logout(): React.ReactElement {
       });
 
       signOut();
-      //window.location.href = urlWithRedirect;
+      window.location.href = urlWithRedirect;
     }
   }, [
     token,

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -56,9 +56,12 @@ export async function fetchEkirjastoToken(
         detail: "No URL for token refresh was provided"
       });
     }
-    const { access_token: accessToken } = await fetchEAuthToken(refreshUrl, token)
+    const { access_token: accessToken } = await fetchEAuthToken(
+      refreshUrl,
+      token
+    );
     //set refresh to undef so we don't end up in a loop
-    return fetchEkirjastoToken(url,accessToken, undefined)
+    return fetchEkirjastoToken(url, accessToken, undefined);
   }
 
   return json;

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -56,9 +56,9 @@ export async function fetchEkirjastoToken(
         detail: "No URL for token refresh was provided"
       });
     }
-    //const { access_token: accessToken } = await fetchEAuthToken(refreshUrl, token)
+    const { access_token: accessToken } = await fetchEAuthToken(refreshUrl, token)
     //set refresh to undef so we don't end up in a loop
-    //return fetchEkirjastoToken(url,accessToken, undefined)
+    return fetchEkirjastoToken(url,accessToken, undefined)
   }
 
   return json;

--- a/src/auth/ekirjastoFetch.ts
+++ b/src/auth/ekirjastoFetch.ts
@@ -32,7 +32,8 @@ export async function fetchEAuthToken(
 
 export async function fetchEkirjastoToken(
   url: string | undefined,
-  token: string | undefined
+  token: string | undefined,
+  refreshUrl: string | undefined
 ) {
   if (!url || !token) {
     throw new ApplicationError({
@@ -47,6 +48,17 @@ export async function fetchEkirjastoToken(
   //If we get a 401, refresh is going to happen so we don't want to throw an error
   if (!response.ok && response.status !== 401) {
     throw new ServerError(url, response.status, json);
+  }
+  if (response.status === 401) {
+    if (!refreshUrl) {
+      throw new ApplicationError({
+        title: "Incomplete Token Refresh Info",
+        detail: "No URL for token refresh was provided"
+      });
+    }
+    //const { access_token: accessToken } = await fetchEAuthToken(refreshUrl, token)
+    //set refresh to undef so we don't end up in a loop
+    //return fetchEkirjastoToken(url,accessToken, undefined)
   }
 
   return json;

--- a/src/components/context/UserContext.tsx
+++ b/src/components/context/UserContext.tsx
@@ -26,7 +26,8 @@ export type UserState = {
   signOut: () => void;
   getEkirjastoToken: (
     token: string,
-    fetchUrl: string | undefined
+    fetchUrl?: string,
+    refreshUrl?: string
   ) => Promise<string>;
   setBook: (book: AnyBook, id?: string) => void;
   setSelected: (book: AnyBook, id?: string) => void;
@@ -158,11 +159,13 @@ export const UserProvider = ({ children }: UserProviderProps) => {
 
   async function getEkirjastoToken(
     token: string,
-    fetchUrl: string | undefined
+    fetchUrl?: string,
+    refreshUrl?: string
   ): Promise<string> {
     const { token: ekirjastoToken } = await fetchEkirjastoToken(
       fetchUrl,
-      token
+      token,
+      refreshUrl
     );
     return ekirjastoToken;
   }


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
This pr adjusts and attempts to make the logging out more robust.

The changes include:
- Logout now handles 401 answer to the fetching of the ekirjasto token. Previously the token was refreshed elsewhere but the logout did not happen, thus making the user go through the logout motions twice. 
- Ensure the local logout happens before the server logout.
- The code now assumes less things to be available, and attempts to take into account some missing information.

## How Can This Be Tested?

- [x] This change cannot be tested visually

401 handling can be tested by:
1. Logging in
2. Wait 10 mins for token to expire
3. Press logout and confirm
4. Logging out should happen correctly without any more input needed from the user.

There are no other visual changes to be seen really.

NOTE: When checking the logout with the expired token, the token refresh is done 3 times, once by loans, once by selected, once by logout. This is not ideal, but the easiest answer. Previously the refresh is done only twice, but the logout would not happen.

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
