### PR TITLE
EKIRJASTO-816-708 Update user redirects

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -169,6 +169,7 @@
   "mediumIndicator.labelForBook": "Book",
   "mediumIndicator.labelForeBook": "eBook",
   "multiLibraryHome.chooseLibrary": "Choose a library",
+  "multiLibraryHome.noLibraries": "No libraries available",
   "myBooks.breadcrumb": "My Books",
   "myBooks.emptyFavorites": "Your favorite books will show up here when you have any selected.",
   "myBooks.emptyLoansAndHolds": "Your books will show up here when you have any loaned or on hold.",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -199,5 +199,6 @@
   "useBorrow.borrowing": "Borrowing...",
   "useBorrow.reserveBook": "Reserve",
   "useBorrow.reserving": "Reserving...",
-  "useBorrow.signInToBorrow": "You must be signed in to borrow this book."
+  "useBorrow.signInToBorrowOrReserve": "You must be signed in to borrow or reserve this book.",
+  "useSelectBook.signInToAddToFavorites": "You must be signed in to add this book to Favorites."
 }

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -169,6 +169,7 @@
   "mediumIndicator.labelForBook": "Kirja",
   "mediumIndicator.labelForeBook": "E-kirja",
   "multiLibraryHome.chooseLibrary": "Valitse kirjasto",
+  "multiLibraryHome.noLibraries": "Ei käytettävissä olevia kirjastoja",
   "myBooks.breadcrumb": "Kirjani",
   "myBooks.emptyFavorites": "Sinulla ei ole vielä suosikkeja. Voit lisätä suosikkeja, kun selaat kirjoja.",
   "myBooks.emptyLoansAndHolds": "Sinulla ei ole voimassa olevia lainoja.",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -199,5 +199,6 @@
   "useBorrow.borrowing": "Lainataan...",
   "useBorrow.reserveBook": "Varaa tämä kirja",
   "useBorrow.reserving": "Varataan...",
-  "useBorrow.signInToBorrow": "Sinun tulee olla kirjautuneena lainataksesi tämän kirjan."
+  "useBorrow.signInToBorrowOrReserve": "Sinun tulee olla kirjautuneena lainataksesi tai varataksesi tämän kirjan.",
+  "useSelectBook.signInToAddToFavorites": "Sinun tulee olla kirjautuneena lisätäksesi tämän kirjan suosikkeihin."
 }

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -199,5 +199,6 @@
   "useBorrow.borrowing": "Lånar...",
   "useBorrow.reserveBook": "Reservera denna bok",
   "useBorrow.reserving": "Reserverar...",
-  "useBorrow.signInToBorrow": "Du måste vara inloggad för att låna denna bok."
+  "useBorrow.signInToBorrowOrReserve": "Du måste vara inloggad för att låna eller reservera denna bok.",
+  "useSelectBook.signInToAddToFavorites": "Du måste vara inloggad för att lägga till denna bok i favoriter."
 }

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -169,6 +169,7 @@
   "mediumIndicator.labelForBook": "Bok",
   "mediumIndicator.labelForeBook": "E-bok",
   "multiLibraryHome.chooseLibrary": "Välj ett bibliotek",
+  "multiLibraryHome.noLibraries": "Inga bibliotek tillgängliga",
   "myBooks.breadcrumb": "Mina böcker",
   "myBooks.emptyFavorites": "Gå till Katalogen för att lägga till böcker till dina Favoriter.",
   "myBooks.emptyLoansAndHolds": "Besök katalogen för att lägga till böcker i Mina lån.",

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -16,28 +16,40 @@ const MultiLibraryHome: React.FC = () => {
 
   if (!libraries || slugs.length === 0) return null;
 
-  return (
-    <ThemeUIProvider theme={theme}>
-      <Themed.root
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          minHeight: "100vh",
-          m: 3
-        }}
-      >
-        <h1>{instanceName}</h1>
-        <h3>{t("multiLibraryHome.chooseLibrary")}</h3>
-        <ul>
-          {slugs.map(slug => (
-            <li key={slug}>
-              <Link href={`/${slug}`}>/{libraries[slug]?.title}</Link>
-            </li>
-          ))}
-        </ul>
-      </Themed.root>
-    </ThemeUIProvider>
-  );
+  return renderLibrarySelection(instanceName, t, slugs, libraries);
 };
+
+// helper function that renders the library selection list
+const renderLibrarySelection = (
+  instanceName: string,
+  t: any,
+  slugs: string[],
+  libraries: Record<string, { title: string; authDocUrl: string } | undefined>
+) => (
+  <ThemeUIProvider theme={theme}>
+    <Themed.root
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        minHeight: "100vh",
+        m: 3
+      }}
+    >
+      {/* render app name and header */}
+      <h1>{instanceName}</h1>
+      <h3>{t("multiLibraryHome.chooseLibrary")}</h3>
+
+      {/* render list of libraries */}
+      <ul>
+        {slugs.map(slug => (
+          <li key={slug}>
+            {/* render library title as a link leading to library's frontpage */}
+            <Link href={`/${slug}`}>{libraries[slug]?.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </Themed.root>
+  </ThemeUIProvider>
+);
 
 export default MultiLibraryHome;

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -14,10 +14,26 @@ const MultiLibraryHome: React.FC = () => {
   const slugs = Object.keys(libraries);
   const { t } = useTranslation();
 
-  if (!libraries || slugs.length === 0) return null;
+  // just in case check if we have no libraries
+  // and show user the "No libraries available" page
+  // (this should not happen for E-kirjasto)
+  if (!libraries || slugs.length === 0) {
+    return renderNoLibraries(instanceName, t);
+  }
 
   return renderLibrarySelection(instanceName, t, slugs, libraries);
 };
+
+// helper function that renders the "No libraries available"
+const renderNoLibraries = (instanceName: string, t: any) => (
+  <ThemeUIProvider theme={theme}>
+    <Themed.root sx={{ m: 3 }}>
+      {/* render app name and header only */}
+      <h1>{instanceName}</h1>
+      <h3>{t("multiLibraryHome.noLibraries")}</h3>
+    </Themed.root>
+  </ThemeUIProvider>
+);
 
 // helper function that renders the library selection list
 const renderLibrarySelection = (

--- a/src/components/MultiLibraryHome.tsx
+++ b/src/components/MultiLibraryHome.tsx
@@ -1,27 +1,87 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { jsx, ThemeUIProvider } from "theme-ui";
-import { Themed } from "@theme-ui/mdx";
 import * as React from "react";
-import Link from "next/link";
 import { APP_CONFIG } from "utils/env";
-import theme from "theme/theme";
+import { jsx, ThemeUIProvider } from "theme-ui";
+import { NextRouter, useRouter } from "next/router";
+import { PageLoader } from "components/LoadingIndicator";
 import { useTranslation } from "next-i18next";
+import { Themed } from "@theme-ui/mdx";
+import Link from "next/link";
+import theme from "theme/theme";
 
+/**
+ * Handles the app library routing logic
+ * based on the number of available libraries.
+ *
+ * - if there is only one library => user is redirected to that library's frontpage
+ * - if there are no libraries => "No libraries available" is rendered
+ * - if multiple libraries are available =>  a selection list of libraries is rendered
+ */
 const MultiLibraryHome: React.FC = () => {
   const { libraries, instanceName } = APP_CONFIG;
-  const slugs = Object.keys(libraries);
+  const slugs = Object.keys(libraries ?? {});
   const { t } = useTranslation();
+  const router = useRouter();
+
+  // define state to handle showing loading indicator
+  // set initial state to loading=true
+  const [loading, setLoading] = React.useState(true);
+
+  // effect that calls handleLibraryRouting function
+  // to handle loading state and the app's routing logic
+  // based on the number of libraries (slugs) available
+  React.useEffect(() => {
+    handleLibraryRouting(slugs, router, setLoading);
+  }, [slugs, router]);
+
+  // show loading indicator while fetching data
+  if (loading) return <PageLoader />;
 
   // just in case check if we have no libraries
   // and show user the "No libraries available" page
   // (this should not happen for E-kirjasto)
-  if (!libraries || slugs.length === 0) {
+  if (slugs.length === 0) {
     return renderNoLibraries(instanceName, t);
   }
 
+  // show user the library selection list
+  // (this should not happen for E-kirjasto because
+  // the user should already be redirected to the E-kirjasto frontpage)
   return renderLibrarySelection(instanceName, t, slugs, libraries);
+};
+
+// helper function that updates the loading state
+// and also handles redirection in the case
+// that there is only one library
+const handleLibraryRouting = (
+  slugs: string[],
+  router: NextRouter,
+  setLoading: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  // check the special case:
+  // if only one library is found
+  if (slugs.length === 1) {
+    // one library found!
+    // note: this should be the E-kirjasto case
+
+    // first get the slug
+    // note: this should be "ekirjasto"
+    const singleLibrarySlug = slugs[0];
+
+    // then redirect the user to the frontpage
+    // of this single library
+    // note: this is the "/ekirjasto" route
+    router.replace(`/${singleLibrarySlug}`);
+
+    // and return early after redirection
+    return;
+  }
+
+  // all other cases (we have no libraries found
+  // or we have multiple libraries):
+  // just stop the loading state
+  setLoading(false);
 };
 
 // helper function that renders the "No libraries available"

--- a/src/components/SelectBookCard.tsx
+++ b/src/components/SelectBookCard.tsx
@@ -30,7 +30,7 @@ const SelectBookButton: React.FC<{
     : t("selectBookCard.addToFavorites");
 
   return (
-    <div>
+    <div sx={{ mt: 1, mb: 1 }}>
       <Button
         onClick={onClick}
         loading={isLoading}
@@ -47,14 +47,19 @@ const SelectBookButton: React.FC<{
       >
         {buttonLabel}
       </Button>
-      {error && <Text sx={{ color: "ui.error", fontSize: "-1" }}>{error}</Text>}
+      {/* render the possible error message below the button */}
+      {error && (
+        <p sx={{ mt: 1, mb: 1 }}>
+          <Text sx={{ color: "ui.error" }}>{error}</Text>
+        </p>
+      )}
     </div>
   );
 };
 
 const SelectBookCard: React.FC<SelectBookProps> = ({ book }) => {
   const { t } = useTranslation();
-  const { isLoading, toggleSelection } = useSelectBook();
+  const { isLoading, error, toggleSelection } = useSelectBook();
   const { selected } = useUser();
   // Initial selection state is checked against the user's selected books
   const isSelected =
@@ -71,6 +76,7 @@ const SelectBookCard: React.FC<SelectBookProps> = ({ book }) => {
         isSelected={isSelected}
         isLoading={isLoading}
         onClick={handleClick}
+        error={error ?? undefined}
       />
     </div>
   );

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -81,8 +81,8 @@ test("redirects to login when not signed in", async () => {
   // doesn't call the borrow book
   expect(mockedFetchBook).not.toHaveBeenCalled();
 
-  // redirects to login
-  expect(mockPush).toHaveBeenCalledWith(
+  // should not redirect to login
+  expect(mockPush).not.toHaveBeenCalledWith(
     {
       pathname: "/[library]/login",
       query: { library: "testlib", nextUrl: "/testlib" }

--- a/src/components/__tests__/BorrowOrReserve.test.tsx
+++ b/src/components/__tests__/BorrowOrReserve.test.tsx
@@ -75,7 +75,7 @@ test("redirects to login when not signed in", async () => {
 
   // error is there
   expect(
-    screen.getByText("Error: You must be signed in to borrow this book.")
+    screen.getByText("You must be signed in to borrow or reserve this book.")
   ).toBeInTheDocument();
 
   // doesn't call the borrow book
@@ -111,7 +111,7 @@ test("catches and displays server errors", async () => {
   // shows the error, button resets.
   await waitFor(() => {
     expect(
-      screen.getByText("Error: Something happened on the server")
+      screen.getByText("Something happened on the server")
     ).toBeInTheDocument();
     expect(screen.queryByText("Borrowing...")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Borrow" })).toBeInTheDocument();

--- a/src/components/__tests__/MultiLibraryHome.test.tsx
+++ b/src/components/__tests__/MultiLibraryHome.test.tsx
@@ -1,0 +1,77 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import mockConfig from "test-utils/mockConfig";
+import MultiLibraryHome from "components/MultiLibraryHome";
+
+// mock the next/router first
+// to prevent tests using the actual router
+jest.mock("next/router", () => ({
+  // define mock for the useRouter hook
+  useRouter: jest.fn()
+}));
+
+// helper function to mock next/router with specific parameters
+const mockRouter = () => {
+  // define mock implementation of the replace function
+  const replace = jest.fn(() => Promise.resolve());
+
+  // define the return value for the useRouter mock
+  (require("next/router").useRouter as jest.Mock).mockReturnValue({
+    replace
+  });
+
+  // return the mocked replace function for assertions in tests
+  return replace;
+};
+
+describe("MultiLibraryHome", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows 'No libraries available' when no libraries exist", async () => {
+    // mock config with no libraries
+    mockConfig({ libraries: {} });
+
+    render(<MultiLibraryHome />);
+
+    await waitFor(() =>
+      expect(screen.getByText("No libraries available")).toBeInTheDocument()
+    );
+
+    expect(screen.getByText("Test Instance")).toBeInTheDocument();
+  });
+
+  it("redirects to library when only one library exists", async () => {
+    // the default config mock has one library
+    mockConfig();
+    const replace = mockRouter();
+
+    render(<MultiLibraryHome />);
+
+    await waitFor(() => {
+      expect(replace).toHaveBeenCalledWith("/lib1");
+    });
+  });
+
+  it("shows list of libraries when multiple libraries exist", async () => {
+    // mock config with three libraries
+    mockConfig({
+      libraries: {
+        library1: { title: "Library-1", authDocUrl: "url-1" },
+        library2: { title: "Library-2", authDocUrl: "url-2" },
+        library3: { title: "Library-3", authDocUrl: "url-3" }
+      }
+    });
+
+    render(<MultiLibraryHome />);
+
+    await waitFor(() =>
+      expect(screen.getByText("Choose a library")).toBeInTheDocument()
+    );
+
+    expect(screen.getByText("Library-1")).toBeInTheDocument();
+    expect(screen.getByText("Library-2")).toBeInTheDocument();
+    expect(screen.getByText("Library-3")).toBeInTheDocument();
+  });
+});

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -78,7 +78,7 @@ describe("BorrowableBook", () => {
 
     // the borrow button should be gone now
     await waitForElementToBeRemoved(() => screen.queryByText("Borrowing..."));
-    expect(screen.getByText("Error: Can't do that"));
+    expect(screen.getByText("Can't do that"));
   });
 });
 
@@ -118,7 +118,7 @@ describe("OnHoldBook", () => {
 
     // the borrow button should be gone now
     await waitForElementToBeRemoved(() => screen.queryByText("Borrowing..."));
-    expect(screen.getByText("Error: Can't do that"));
+    expect(screen.getByText("Can't do that"));
   });
 
   test("handles lack of availability.until info", () => {
@@ -207,7 +207,7 @@ describe("ReservableBook", () => {
 
     // the borrow button should be gone now
     await waitForElementToBeRemoved(() => screen.queryByText("Reserving..."));
-    expect(screen.getByText("Error: Can't do that"));
+    expect(screen.getByText("Can't do that"));
   });
 });
 
@@ -282,7 +282,7 @@ describe("reserved", () => {
       "en"
     );
 
-    expect(await screen.findByText("Error: Can't do that")).toBeInTheDocument();
+    expect(await screen.findByText("Can't do that")).toBeInTheDocument();
     expect(
       await screen.findByRole("button", { name: "Cancel Reservation" })
     ).toBeInTheDocument();
@@ -543,9 +543,7 @@ describe("FulfillableBook", () => {
 
     fireEvent.click(downloadButton);
 
-    expect(
-      await screen.findByText("Error: You can't do that")
-    ).toBeInTheDocument();
+    expect(await screen.findByText("You can't do that")).toBeInTheDocument();
   });
 
   test("reattempts downloads without headers upon redirect failure", async () => {

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -25,7 +25,7 @@ export default function useBorrow(isBorrow: boolean) {
   const borrowOrReserve = async (url: string) => {
     clearError();
     if (!token) {
-      setErrorString(t("useBorrow.signInToBorrow"));
+      setErrorString(t("useBorrow.signInToBorrowOrReserve"));
       return;
     }
     setLoading(true);

--- a/src/hooks/useBorrow.ts
+++ b/src/hooks/useBorrow.ts
@@ -3,14 +3,12 @@ import { fetchBook } from "dataflow/opds1/fetch";
 import useUser from "components/context/UserContext";
 import useLibraryContext from "components/context/LibraryContext";
 import useError from "hooks/useError";
-import useLogin from "auth/useLogin";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 
 export default function useBorrow(isBorrow: boolean) {
   const { catalogUrl } = useLibraryContext();
   const { setBook, token } = useUser();
-  const { initLogin } = useLogin();
   const isUnmounted = React.useRef(false);
   const [isLoading, setLoading] = React.useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
@@ -27,7 +25,6 @@ export default function useBorrow(isBorrow: boolean) {
   const borrowOrReserve = async (url: string) => {
     clearError();
     if (!token) {
-      initLogin();
       setErrorString(t("useBorrow.signInToBorrow"));
       return;
     }

--- a/src/hooks/useError.ts
+++ b/src/hooks/useError.ts
@@ -12,7 +12,7 @@ export default function useError() {
   function handleError(e: any) {
     track.error(e);
     if (e instanceof ServerError) {
-      setError(`Error: ${e.info.detail}`);
+      setError(e.info.detail);
       return;
     }
     setError("Error: An unknown error occurred.");
@@ -20,7 +20,7 @@ export default function useError() {
 
   // for internal error states we don't need to track
   function setErrorString(str: string) {
-    setError(`Error: ${str}`);
+    setError(str);
   }
 
   function clearError() {

--- a/src/hooks/useSelectBook.ts
+++ b/src/hooks/useSelectBook.ts
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { AnyBook } from "interfaces";
 import useUser from "components/context/UserContext";
 import useError from "hooks/useError";
+import { useTranslation } from "next-i18next";
 
 /**
  * Return type for the useSelectBook hook.
@@ -35,6 +36,7 @@ export default function useSelectBook(): UseSelectBookResult {
   const { token, setSelected } = useUser();
   const [isLoading, setIsLoading] = useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
+  const { t } = useTranslation();
 
   /**
    * Toggles the selection state of a book by making an API request.
@@ -59,7 +61,7 @@ export default function useSelectBook(): UseSelectBookResult {
     clearError();
 
     if (!token) {
-      setErrorString("You must be signed in to select this book.");
+      setErrorString(t("useSelectBook.signInToAddToFavorites"));
       return false;
     }
 

--- a/src/hooks/useSelectBook.ts
+++ b/src/hooks/useSelectBook.ts
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { AnyBook } from "interfaces";
 import useUser from "components/context/UserContext";
-import useLogin from "auth/useLogin";
 import useError from "hooks/useError";
 
 /**
@@ -34,7 +33,6 @@ interface UseSelectBookResult {
  */
 export default function useSelectBook(): UseSelectBookResult {
   const { token, setSelected } = useUser();
-  const { initLogin } = useLogin();
   const [isLoading, setIsLoading] = useState(false);
   const { error, handleError, setErrorString, clearError } = useError();
 
@@ -61,7 +59,6 @@ export default function useSelectBook(): UseSelectBookResult {
     clearError();
 
     if (!token) {
-      initLogin();
       setErrorString("You must be signed in to select this book.");
       return false;
     }


### PR DESCRIPTION
## Description

- This pull requests makes changes to E-kirjasto web app's redirection logic
- E-kirjasto frontpage now opens automatically for users
  - if there is only one library available, users are redirected to that library's homepage
  - this is a (temporary) client-side fix for the current multilibrary support situation
- A message is displayed to inform the users that they need to log in before trying to do book actions
  - users are not automatically redirected to the login page if they try to borrow, reserve or select a book without logging in first
- [EKIRJASTO-816](https://jira.it.helsinki.fi/browse/EKIRJASTO-816), related also [EKIRJASTO-708](https://jira.it.helsinki.fi/browse/EKIRJASTO-708)

## How can this be tested?

- review the `MultiLibraryHome` component and book action hooks
- run the app
  - check that you are automatically redirected to the E-kirjasto homepage
  - you can simulate slow network using the network throttling helper tool in browser's developer tools or the Network Link Conditioner tool in macOS
  - if you want, you can mock situation where no libraries are available to see the _No libraries available_ page
  - if you want, you can mock situation where you have multiple libraries are available and check that libraries list is shown
- try to use the `Borrow` or `Reserve` button and `Add to Favorites` buttons without logging in 
  - check that a message is shown that instructs you to login
  - check that you are not automatically redirected to login

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [x] Tested with Firefox
- [x] Tested with Chrome
- [x] Tested with Edge
- [x] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
