### PR TITLE
EKIRJASTO-811-823-825-826-830 Show more data in book details page

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -73,7 +73,7 @@
   "bookPassphrase.ariaLabelForCopyButton": "Copy book passphrase",
   "bookPassphrase.ariaLabelForPassphrase": "Book passphrase",
   "bookPassphrase.hidePassphrase": "Hide passphrase",
-  "bookPassphrase.instructionsText": "If you download the book, please copy the password below for your EPUB reader.",
+  "bookPassphrase.instructionsText": "If you are using the Thorium Reader application, you will need the password below to open your downloaded book.",
   "bookPassphrase.showPassphrase": "Show passphrase",
   "bookStatus.availableToBorrow": "This book is available to borrow",
   "bookStatus.inTheApp": "in the E-kirjasto App",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -37,6 +37,7 @@
   "bookDetails.headingForBookFormat": "Book format",
   "bookDetails.headingForCategories": "Categories",
   "bookDetails.headingForIsbn": "ISBN",
+  "bookDetails.headingForLanguage": "Language",
   "bookDetails.headingForPublished": "Published",
   "bookDetails.headingForPublisher": "Publisher",
   "bookDetails.labelForComplaintType": "Complaint Type",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -36,6 +36,7 @@
   "bookDetails.headingForAudience": "Audience",
   "bookDetails.headingForBookFormat": "Book format",
   "bookDetails.headingForCategories": "Categories",
+  "bookDetails.headingForIsbn": "ISBN",
   "bookDetails.headingForPublished": "Published",
   "bookDetails.headingForPublisher": "Publisher",
   "bookDetails.labelForComplaintType": "Complaint Type",

--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -86,6 +86,7 @@
   "breadcrumbBar.currentLocation": "Current location: ",
   "cancelOrReturn.signIn": "You must be signed in.",
   "collection.empty": "This collection is empty.",
+  "collection.title": "E-library collection",
   "ekirjastoLogoGreenENNoBackground.title": "The logo for E-library service, a softly stylized green capital letter E that resembles for example a book or a stack of books",
   "error.error": "Error",
   "error.returnHome": "Return Home",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -86,6 +86,7 @@
   "breadcrumbBar.currentLocation": "Nykyinen sijainti:",
   "cancelOrReturn.signIn": "Sinun tulee olla kirjautuneena.",
   "collection.empty": "Kokoelma on tyhjä.",
+  "collection.title": "E-kirjaston kokoelma",
   "ekirjastoLogoGreenENNoBackground.title": "E-kirjasto-palvelun logo, pyöreämuotoiseksi tyylitelty vihreä iso E-kirjain, joka muistuttaa esimerkiksi kirjaa tai kirjapinoa.",
   "error.error": "Virhe",
   "error.returnHome": "Palaa etusivulle",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -73,7 +73,7 @@
   "bookPassphrase.ariaLabelForCopyButton": "Kopioi kirjan salasana",
   "bookPassphrase.ariaLabelForPassphrase": "Kirjan salasana",
   "bookPassphrase.hidePassphrase": "Piilota salasana",
-  "bookPassphrase.instructionsText": "Jos lataat kirjan, kopioi alla oleva salasana EPUB-lukijaa varten.",
+  "bookPassphrase.instructionsText": "Jos käytät Thorium Reader-lukuohjelmaa, tarvitset alla olevan salasanan lataamasi kirjan avaamiseen.",
   "bookPassphrase.showPassphrase": "Näytä salasana",
   "bookStatus.availableToBorrow": "Tämän kirjan voi lainata",
   "bookStatus.inTheApp": "E-kirjasto-sovelluksessa",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -37,6 +37,7 @@
   "bookDetails.headingForBookFormat": "Tiedostomuoto",
   "bookDetails.headingForCategories": "Luokat",
   "bookDetails.headingForIsbn": "ISBN",
+  "bookDetails.headingForLanguage": "Kieli",
   "bookDetails.headingForPublished": "Julkaistu",
   "bookDetails.headingForPublisher": "Kustantaja",
   "bookDetails.labelForComplaintType": "Ongelman tyyppi",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -36,6 +36,7 @@
   "bookDetails.headingForAudience": "Kohderyhmä",
   "bookDetails.headingForBookFormat": "Tiedostomuoto",
   "bookDetails.headingForCategories": "Luokat",
+  "bookDetails.headingForIsbn": "ISBN",
   "bookDetails.headingForPublished": "Julkaistu",
   "bookDetails.headingForPublisher": "Kustantaja",
   "bookDetails.labelForComplaintType": "Ongelman tyyppi",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -73,7 +73,7 @@
   "bookPassphrase.ariaLabelForCopyButton": "Kopiera boklösenord",
   "bookPassphrase.ariaLabelForPassphrase": "Boklösenord",
   "bookPassphrase.hidePassphrase": "Dölj lösenord",
-  "bookPassphrase.instructionsText": "Om du laddar ner boken, kopiera lösenordet nedan för din EPUB-läsare.",
+  "bookPassphrase.instructionsText": "Om du använder läsprogrammet Thorium Reader behöver du lösenordet nedan för att öppna boken du har laddat ner.",
   "bookPassphrase.showPassphrase": "Visa lösenord",
   "bookStatus.availableToBorrow": "Denna bok är tillgånglig föt utlåning",
   "bookStatus.inTheApp": "i E-bibliotekets app",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -37,6 +37,7 @@
   "bookDetails.headingForBookFormat": "Bokformat",
   "bookDetails.headingForCategories": "Kategorier",
   "bookDetails.headingForIsbn": "ISBN",
+  "bookDetails.headingForLanguage": "Språk",
   "bookDetails.headingForPublished": "Utgiven",
   "bookDetails.headingForPublisher": "Utgivare",
   "bookDetails.labelForComplaintType": "Problemtyp",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -36,6 +36,7 @@
   "bookDetails.headingForAudience": "Målgrupp",
   "bookDetails.headingForBookFormat": "Bokformat",
   "bookDetails.headingForCategories": "Kategorier",
+  "bookDetails.headingForIsbn": "ISBN",
   "bookDetails.headingForPublished": "Utgiven",
   "bookDetails.headingForPublisher": "Utgivare",
   "bookDetails.labelForComplaintType": "Problemtyp",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -86,6 +86,7 @@
   "breadcrumbBar.currentLocation": "Aktuell plats:",
   "cancelOrReturn.signIn": "Du måste vara inloggad.",
   "collection.empty": "Denna samling är tom.",
+  "collection.title": "E-bibliotekets samling",
   "ekirjastoLogoGreenENNoBackground.title": "Logotypen för E-bibliotekstjänsten, en rundat stiliserad grön versal E som påminner om till exempel en bok eller en bokhög.",
   "error.error": "Fel",
   "error.returnHome": "Tillbaka till startsidan",

--- a/src/components/Collection.tsx
+++ b/src/components/Collection.tsx
@@ -27,7 +27,9 @@ export const Collection: React.FC<{
 
   const hasLanes = collection?.lanes && collection.lanes.length > 0;
   const hasBooks = collection?.books && collection.books.length > 0;
-  const pageTitle = isLoading ? "" : title ?? collection?.title ?? "Collection";
+  const pageTitle = isLoading
+    ? ""
+    : title ?? collection?.title ?? t("collection.title");
 
   // get the breadcrumbs context
   const { storedBreadcrumbs, setStoredBreadcrumbs } = useBreadcrumbContext();

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -126,6 +126,13 @@ describe("book details page", () => {
     expect(screen.getByText("ePub")).toBeInTheDocument();
   });
 
+  test("shows ISBN", () => {
+    mockSwr({ data: fixtures.book });
+    setup(<BookDetails />);
+    expect(screen.getByText("ISBN:")).toBeInTheDocument();
+    expect(screen.getByText("9780123456789")).toBeInTheDocument();
+  });
+
   test("shows accessibility information", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -119,6 +119,13 @@ describe("book details page", () => {
     setup(<BookDetails />);
   });
 
+  test("shows language", () => {
+    mockSwr({ data: fixtures.book });
+    setup(<BookDetails />);
+    expect(screen.getByText("Language:")).toBeInTheDocument();
+    expect(screen.getByText("en")).toBeInTheDocument();
+  });
+
   test("shows book format", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);

--- a/src/components/bookDetails/__tests__/BookDetails.test.tsx
+++ b/src/components/bookDetails/__tests__/BookDetails.test.tsx
@@ -133,6 +133,13 @@ describe("book details page", () => {
     expect(screen.getByText("ePub")).toBeInTheDocument();
   });
 
+  test("shows published", () => {
+    mockSwr({ data: fixtures.book });
+    setup(<BookDetails />);
+    expect(screen.getByText("Published:")).toBeInTheDocument();
+    expect(screen.getByText("2016")).toBeInTheDocument();
+  });
+
   test("shows ISBN", () => {
     mockSwr({ data: fixtures.book });
     setup(<BookDetails />);

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -35,14 +35,24 @@ export const BookDetails: React.FC = () => {
   const { catalogUrl } = useLibraryContext();
   const bookUrl = extractParam(query, "bookUrl");
 
-  // define cache key (unique) for SWR based on bookUrl and locale.
-  // note: if bookUrl or locale is missing we don't fetch anything
-  const key = bookUrl && locale ? [bookUrl, locale] : null;
+  // define cache key (unique) for SWR based on
+  // bookUrl, locale and catalogUrl.
+  // note: if bookUrl or locale (or catalogUrl) is missing,
+  // we don't fetch anything
+  const key =
+    bookUrl && locale && catalogUrl
+      ? ([bookUrl, catalogUrl, locale] as const)
+      : null;
 
   // define the fetcher function for SWR.
   // Token is undefined here because authentication
   // is not required the fetch normal book data from backend
-  const fetcher = () => fetchBook(bookUrl, catalogUrl, undefined, locale);
+  const fetcher = (
+    urlForBook: string,
+    urlForCatalog: string,
+    appLocale: string
+  ): Promise<AnyBook> =>
+    fetchBook(urlForBook, urlForCatalog, undefined, appLocale);
 
   // SWR calls fetchBook when it needs new data
   // data is the fetched book and error is any happened error during fetching
@@ -52,7 +62,8 @@ export const BookDetails: React.FC = () => {
   const { loans } = useUser();
   // always use the MyBooks version of the book, if it is available
   // otherwise, just use the fetched data as the book
-  const book = loans?.find(loanedBook => data?.id === loanedBook.id) ?? data;
+  const book: AnyBook =
+    loans?.find(loanedBook => data?.id === loanedBook.id) ?? data;
 
   const subtitle = getSubtitle(book);
   const { t } = useTranslation();

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -166,6 +166,12 @@ export const BookDetails: React.FC = () => {
                 heading={t("bookDetails.headingForAgeRange")}
                 details={book.ageRange?.join(", ")}
               />
+
+              <DetailField
+                heading={t("bookDetails.headingForLanguage")}
+                details={book.language}
+              />
+
               <DetailField
                 heading={t("bookDetails.headingForBookFormat")}
                 details={book.format}

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -170,6 +170,12 @@ export const BookDetails: React.FC = () => {
                 heading={t("bookDetails.headingForBookFormat")}
                 details={book.format}
               />
+
+              <DetailField
+                heading={t("bookDetails.headingForIsbn")}
+                details={book.isbn}
+              />
+
               <Accessibility book={book} sx={{ mt: 3 }} />
             </div>
 

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -168,6 +168,7 @@ test("extracts basic book info", () => {
   expect(book.summary).not.toMatch(/script/);
   expect(book.summary).not.toMatch(/danger/);
   expect(book.categories?.length).toBe(2);
+  expect(book.language).toBe(entry.language);
   expect(book.categories).toContain("label");
   expect(book.categories).toContain("label 2");
   expect(book.imageUrl).toBe(thumbImageLink.href);

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -79,7 +79,7 @@ test("extracts basic book info", () => {
   });
 
   const entry = factory.entry({
-    id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr91",
+    id: "urn:isbn:9780123456789",
     title: "The Mayan Secrets",
     authors: [
       factory.contributor({ name: "Clive Cussler" }),
@@ -179,6 +179,7 @@ test("extracts basic book info", () => {
   expect(book.copies).toBe(borrowLink.copies);
   expect(book.status).toBe("unsupported");
   expect(book.trackOpenBookUrl).toBe("/track-open");
+  expect(book.isbn).toBe("9780123456789");
 });
 
 const basicInfo = {

--- a/src/dataflow/opds1/__tests__/parse.test.ts
+++ b/src/dataflow/opds1/__tests__/parse.test.ts
@@ -173,7 +173,7 @@ test("extracts basic book info", () => {
   expect(book.categories).toContain("label 2");
   expect(book.imageUrl).toBe(thumbImageLink.href);
   expect(book.publisher).toBe("Fake Publisher");
-  expect(book.published).toBe("June 8, 2014");
+  expect(book.published).toBe("2014");
   expect(book.language).toBe("en");
   expect(book.availability).toEqual(borrowLink.availability);
   expect(book.holds).toBe(borrowLink.holds);

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -337,6 +337,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
 
   const book: Book = {
     id: entry.id,
+    isbn: entry.id && formatIdToIsbn(entry.id),
     title: entry.title,
     accessibility: entry.accessibility,
     series: entry.series,
@@ -543,6 +544,31 @@ function formatDate(inputDate: string): string {
   const year = date.getUTCFullYear();
 
   return `${month} ${day}, ${year}`;
+}
+
+// function that formats bookId to ISBN
+// book id is usually in format "urn:isbn:9780123456789"
+function formatIdToIsbn(bookId: string): string {
+  // first check if the bookId starts with "urn:isbn:"
+  if (!bookId.startsWith("urn:isbn:")) {
+    // not valid bookID, just return empty string
+    return "";
+  }
+
+  // then extract the substring after "urn:isbn:"
+  const isbn = bookId.substring(9);
+
+  // define a test for checking if characters in a string are all numbers
+  const isbnContainsOnlyNumbers = /^\d+$/.test(isbn);
+
+  // check if there are non-digits in isbn candidate
+  if (!isbnContainsOnlyNumbers) {
+    // return empty string
+    return "";
+  }
+
+  // return the valid ISBN
+  return isbn;
 }
 
 function OPDSLinkToLinkData(

--- a/src/dataflow/opds1/parse.ts
+++ b/src/dataflow/opds1/parse.ts
@@ -357,7 +357,7 @@ export function entryToBook(entry: OPDSEntry, feedUrl: string): AnyBook {
     copies: copies,
     passphrase: passphrases?.unhashedPassphrase,
     publisher: entry.publisher,
-    published: entry.issued && formatDate(entry.issued),
+    published: entry.issued && formatIssuedToPublished(entry.issued),
     categories: categories,
     audience: audience,
     ageRange: ageRange,
@@ -521,29 +521,33 @@ function dedupeBooks(books: AnyBook[]): AnyBook[] {
   return Array.from(bookIndex.values());
 }
 
-function formatDate(inputDate: string): string {
-  const monthNames = [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December"
-  ];
+// function that formats book's issued date to published
+// returns just the year as string
+// or empty string if published date is not available
+function formatIssuedToPublished(bookIssued: string): string {
+  // just to be safe
+  if (!bookIssued) {
+    // just return an empty string
+    return "";
+  }
 
-  const date = new Date(inputDate);
-  const day = date.getUTCDate();
-  const monthIndex = date.getUTCMonth();
-  const month = monthNames[monthIndex];
-  const year = date.getUTCFullYear();
+  // define regex to find YYYY, YYYY-MM or YYYY-MM-DD
+  const dateMatch = /^(\d{4})(?:-\d{2}(?:-\d{2})?)?$/;
 
-  return `${month} ${day}, ${year}`;
+  // try find the match with the issued date
+  const match = bookIssued.match(dateMatch);
+
+  if (!match) {
+    // no matching format,
+    // just return empty string
+    return "";
+  }
+
+  // year can be found in the match array
+  const yearString = match[1];
+
+  // return just the year
+  return yearString;
 }
 
 // function that formats bookId to ISBN

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -161,6 +161,7 @@ export type BookAvailability =
 export type Book<Status = EmptyObject> = Readonly<
   Status & {
     id: string;
+    isbn?: string;
     title: string;
     accessibility?: {
       conformance?: {

--- a/src/pages/[library]/index.tsx
+++ b/src/pages/[library]/index.tsx
@@ -7,7 +7,7 @@ import withAppProps, { AppProps } from "dataflow/withAppProps";
 const LibraryHome: NextPage<AppProps> = ({ library, error }) => {
   return (
     <LayoutPage library={library} error={error}>
-      <Collection title={`${library?.catalogName} Home`} />
+      <Collection title={library?.catalogName} />
     </LayoutPage>
   );
 };

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -82,7 +82,7 @@ export const book: Book = {
     "&lt;b&gt;Sam and Remi Fargo race for treasure&#8212;and survival&#8212;in this lightning-paced new adventure from #1&lt;i&gt; New York Times&lt;/i&gt; bestselling author Clive Cussler.&lt;/b&gt;&lt;br /&gt;&lt;br /&gt;Husband-and-wife team Sam and Remi Fargo are in Mexico when they come upon a remarkable discovery&#8212;the mummified remainsof a man clutching an ancient sealed pot. Within the pot is a Mayan book larger than any known before.&lt;br /&gt;&lt;br /&gt;The book contains astonishing information about the Mayans, their cities, and about mankind itself. The secrets are so powerful that some people would do anything to possess them&#8212;as the Fargos are about to find out. Many men and women are going to die for that book.",
   imageUrl: "https://dlotdqc6pnwqb.cloudfront.net/3M/crrmnr9/cover.jpg",
   publisher: "Penguin Publishing Group",
-  published: "February 29, 2016",
+  published: "2016",
   categories: ["Children", "10-12", "Fiction", "Adventure", "Fantasy"],
   providerName: "Overdrive",
   language: "en",

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -85,6 +85,7 @@ export const book: Book = {
   published: "February 29, 2016",
   categories: ["Children", "10-12", "Fiction", "Adventure", "Fantasy"],
   providerName: "Overdrive",
+  language: "en",
   format: "ePub",
   accessibility: {
     conformance: {

--- a/src/test-utils/fixtures/book.ts
+++ b/src/test-utils/fixtures/book.ts
@@ -70,7 +70,8 @@ export function makeFulfillableBooks(n: number): FulfillableBook[] {
 }
 
 export const book: Book = {
-  id: "urn:librarysimplified.org/terms/id/3M%20ID/crrmnr9",
+  id: "urn:isbn:9780123456789",
+  isbn: "9780123456789",
   relatedUrl: "http://related-url",
   trackOpenBookUrl: "/track-open-book",
   url: "http://test-book-url",


### PR DESCRIPTION
## Description

- This pull request adds more book information to each book
  - book's ISBN, language code and year of publication are now displayed in the book detail view
  - users are now instructed to use Thorium Reader app with book passphrase
  - also: E-kirjasto frontpage now displays only the collection name without the hardcoded "Home" 
- [EKIRJASTO-811](https://jira.it.helsinki.fi/browse/EKIRJASTO-811), [EKIRJASTO-823](https://jira.it.helsinki.fi/browse/EKIRJASTO-823), [EKIRJASTO-825](https://jira.it.helsinki.fi/browse/EKIRJASTO-825), [EKIRJASTO-826](https://jira.it.helsinki.fi/browse/EKIRJASTO-826), [EKIRJASTO-829](https://jira.it.helsinki.fi/browse/EKIRJASTO-829) and [EKIRJASTO-830](https://jira.it.helsinki.fi/browse/EKIRJASTO-830)
 
## How can this be tested?

- open the book detail view (for different books)
  - check that ISBN, published year and language code are shown correctly
  - check that book passphrase instruction about Thorium Reader is clear
- open web app front page
  - check that text _Home_ is not used in the collection title 

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
