### PR TITLE
EKIRJASTO-839 Hide book download button and book passphrase button in UI

### DIFF
--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -29,6 +29,9 @@ const FulfillmentButton: React.FC<{
 }> = ({ details, book, isPrimaryAction }) => {
   switch (details.type) {
     case "download":
+      return null;
+    /*
+      Hide DownloadButton for now
       return (
         <DownloadButton
           details={details}
@@ -36,6 +39,7 @@ const FulfillmentButton: React.FC<{
           isPrimaryAction={isPrimaryAction}
         />
       );
+    */
     case "read-online-internal":
       return (
         <ReadOnlineInternal
@@ -141,6 +145,7 @@ const ReadOnlineInternal: React.FC<{
   );
 };
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const DownloadButton: React.FC<{
   details: DownloadFulfillment;
   title: string;

--- a/src/components/__tests__/BookListItem.test.tsx
+++ b/src/components/__tests__/BookListItem.test.tsx
@@ -286,7 +286,7 @@ describe("FulfillableBook", () => {
     }
   });
 
-  test("displays FulfillmentButton if only one possibility", () => {
+  test.skip("displays FulfillmentButton if only one possibility", () => {
     const book = fixtures.mergeBook<FulfillableBook>({
       status: "fulfillable",
       revokeUrl: "/revoke",

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -429,7 +429,7 @@ describe("FulfillableBook", () => {
       }
     ]
   });
-  test("correct title and subtitle with companion app redirect", () => {
+  test.skip("correct title and subtitle with companion app redirect", () => {
     mockConfig({
       companionApp: "E-kirjasto"
     });
@@ -461,7 +461,8 @@ describe("FulfillableBook", () => {
     expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
   });
 
-  test("shows download options", async () => {
+  // Skip this test for now
+  test.skip("shows download options", async () => {
     setup(<FulfillmentCard book={downloadableBook} />);
     const downloadButton = await screen.findByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
@@ -470,7 +471,7 @@ describe("FulfillableBook", () => {
     expect(PDFButton).toBeInTheDocument();
   });
 
-  test("download button shows loading indicator fetches book", async () => {
+  test.skip("download button shows loading indicator fetches book", async () => {
     setup(<FulfillmentCard book={downloadableBook} />);
     const downloadButton = screen.getByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
@@ -531,7 +532,7 @@ describe("FulfillableBook", () => {
     await screen.findByText(/error:/i);
   });
 
-  test("shows download error message", async () => {
+  test.skip("shows download error message", async () => {
     const problem: ProblemDocument = {
       detail: "You can't do that",
       title: "Wrong!",
@@ -546,7 +547,7 @@ describe("FulfillableBook", () => {
     expect(await screen.findByText("You can't do that")).toBeInTheDocument();
   });
 
-  test("reattempts downloads without headers upon redirect failure", async () => {
+  test.skip("reattempts downloads without headers upon redirect failure", async () => {
     // redirect the user
     fetchMock.once("Bad headers dude!", {
       status: 301,

--- a/src/components/bookDetails/index.tsx
+++ b/src/components/bookDetails/index.tsx
@@ -13,7 +13,7 @@ import { useRouter } from "next/router";
 import * as React from "react";
 import Accessibility from "./Accessibility";
 import BookCover from "../BookCover";
-import BookPassphrase from "./BookPassphrase";
+//import BookPassphrase from "./BookPassphrase";
 import BreadcrumbBar from "../BreadcrumbBar";
 import DetailField from "../BookMetaDetail";
 import extractParam from "dataflow/utils";
@@ -141,7 +141,10 @@ export const BookDetails: React.FC = () => {
 
             <SelectBookCard book={book} />
 
+            {/* 
+            Hide BookPassphrase for now
             <BookPassphrase book={book} />
+            */}
 
             <Summary book={book} sx={{ mt: 3 }} />
 


### PR DESCRIPTION
## Description

- This pull request hides two components in the UI
  - DownloadButton
  - BookPassphrase
- This is quick fix for the UI side for removing book download option from the app temporarily 

## How can this be tested?

- Check the UI
  - check that buttons and texts related to book download are hidden 
  - test that other book functionalities can be used as before 
- Note that some tests are skipped for now
 
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->

- [ ] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
