### PR TITLE
EKIRJASTO-839 Disable download book button in UI

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -125,6 +125,7 @@
   "fulfill.downloadEPUB": "Download EPUB",
   "fulfill.downloadLCPEPUB": "Download LCP EPUB",
   "fulfill.downloadLCPPDF": "Download LCP PDF",
+  "fulfill.downloadNotAvailable": "Book download is currently unavailable.",
   "fulfill.downloadPDF": "Download PDF",
   "fulfill.readOnline": "Read Online",
   "fulfillmentButton.downloading": "Downloading...",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -125,6 +125,7 @@
   "fulfill.downloadEPUB": "Lataa EPUB",
   "fulfill.downloadLCPEPUB": "Lataa LCP EPUB",
   "fulfill.downloadLCPPDF": "Lataa LCP PDF",
+  "fulfill.downloadNotAvailable": "Kirjan lataaminen ei ole toistaiseksi käytettävissä.",
   "fulfill.downloadPDF": "Lataa PDF",
   "fulfill.readOnline": "Lue selaimessa",
   "fulfillmentButton.downloading": "Ladataan...",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -125,6 +125,7 @@
   "fulfill.downloadEPUB": "Ladda ner EPUB",
   "fulfill.downloadLCPEPUB": "Ladda ner LCP EPUB",
   "fulfill.downloadLCPPDF": "Ladda ner LCP PDF",
+  "fulfill.downloadNotAvailable": "Det är för närvarande inte möjligt att ladda ner boken.",
   "fulfill.downloadPDF": "Ladda ner PDF",
   "fulfill.readOnline": "Läs i webbläsaren",
   "fulfillmentButton.downloading": "Laddar ner...",

--- a/src/components/BookList.tsx
+++ b/src/components/BookList.tsx
@@ -292,19 +292,19 @@ const BookListCTA: React.FC<{ book: AnyBook }> = ({ book }) => {
           text={t("bookList.return")}
         />
 
-        {/* then render "Download LCP EPUB" button, if available */}
-        {downloadFulfillment && (
+        {/* render "Read online" button also, if available */}
+        {readOnlineFulfillment && (
           <FulfillmentButton
-            details={downloadFulfillment}
+            details={readOnlineFulfillment}
             book={book}
             isPrimaryAction
           />
         )}
 
-        {/* render "Read online" button also, if available */}
-        {readOnlineFulfillment && (
+        {/* then render "Download LCP EPUB" button, if available */}
+        {downloadFulfillment && (
           <FulfillmentButton
-            details={readOnlineFulfillment}
+            details={downloadFulfillment}
             book={book}
             isPrimaryAction
           />

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -21,6 +21,7 @@ import downloadFile from "dataflow/download";
 import useError from "hooks/useError";
 import useLinkUtils from "hooks/useLinkUtils";
 import { useTranslation } from "next-i18next";
+import Stack from "components/Stack";
 
 const FulfillmentButton: React.FC<{
   details: AnyFullfillment;
@@ -154,6 +155,7 @@ const DownloadButton: React.FC<{
   const { t } = useTranslation();
   const { locale } = useRouter();
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async function download() {
     setLoading(true);
     clearError();
@@ -178,10 +180,13 @@ const DownloadButton: React.FC<{
     setLoading(false);
   }
 
+  const downloadDisabledMessage: string = t("fulfill.downloadNotAvailable");
+
   return (
-    <>
+    <Stack>
       <Button
-        onClick={download}
+        // onClick={download}
+        disabled={true}
         {...getButtonStyles(isPrimaryAction)}
         iconLeft={SvgDownload}
         loading={loading}
@@ -190,6 +195,9 @@ const DownloadButton: React.FC<{
         {t(buttonLabel)}
       </Button>
       {error && <Text sx={{ color: "ui.error" }}>{error}</Text>}
-    </>
+      <Text sx={{ color: "ui.error", fontSize: "-1" }}>
+        {downloadDisabledMessage}
+      </Text>
+    </Stack>
   );
 };

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -102,16 +102,34 @@ const AccessCard: React.FC<{
           {t("bookDetails.readOnComputer")}
         </Text>
       )}
+
       {isFulfillable && (
-        <Stack sx={{ flexWrap: "wrap" }}>
-          {fulfillments.map(details => (
+        <Stack sx={{ flexWrap: "wrap", gap: 2 }}>
+          {/* first render all buttons that are not download */}
+          {fulfillments
+            .filter(details => details.type !== "download")
+            .map(details => (
+              <FulfillmentButton
+                key={details.id}
+                details={details}
+                book={book}
+                isPrimaryAction={!redirectUser}
+              />
+            ))}
+
+          {/* then find and render the download button last */}
+          {fulfillments.find(details => details.type === "download") && (
             <FulfillmentButton
-              key={details.id}
-              details={details}
+              key={
+                fulfillments.find(details => details.type === "download")!.id
+              }
+              details={
+                fulfillments.find(details => details.type === "download")!
+              }
               book={book}
               isPrimaryAction={!redirectUser}
             />
-          ))}
+          )}
         </Stack>
       )}
     </>

--- a/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
+++ b/src/components/bookDetails/__tests__/FulfillmentCard.test.tsx
@@ -461,7 +461,7 @@ describe("FulfillableBook", () => {
     expect(screen.getByText("Ready to Read!")).toBeInTheDocument();
   });
 
-  test("shows download options", async () => {
+  test.skip("shows download options", async () => {
     setup(<FulfillmentCard book={downloadableBook} />);
     const downloadButton = await screen.findByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
@@ -470,7 +470,7 @@ describe("FulfillableBook", () => {
     expect(PDFButton).toBeInTheDocument();
   });
 
-  test("download button shows loading indicator fetches book", async () => {
+  test.skip("download button shows loading indicator fetches book", async () => {
     setup(<FulfillmentCard book={downloadableBook} />);
     const downloadButton = screen.getByText("Download EPUB");
     expect(downloadButton).toBeInTheDocument();
@@ -494,7 +494,7 @@ describe("FulfillableBook", () => {
     });
   });
 
-  test("download button fetches opds entry to indirectly fulfill book", async () => {
+  test.skip("download button fetches opds entry to indirectly fulfill book", async () => {
     const bookWithIndirect = mergeBook<FulfillableBook>({
       ...downloadableBook,
       fulfillmentLinks: [
@@ -531,7 +531,7 @@ describe("FulfillableBook", () => {
     await screen.findByText(/error:/i);
   });
 
-  test("shows download error message", async () => {
+  test.skip("shows download error message", async () => {
     const problem: ProblemDocument = {
       detail: "You can't do that",
       title: "Wrong!",
@@ -546,7 +546,7 @@ describe("FulfillableBook", () => {
     expect(await screen.findByText("You can't do that")).toBeInTheDocument();
   });
 
-  test("reattempts downloads without headers upon redirect failure", async () => {
+  test.skip("reattempts downloads without headers upon redirect failure", async () => {
     // redirect the user
     fetchMock.once("Bad headers dude!", {
       status: 301,


### PR DESCRIPTION
## Description
- This pull request disables the book download button
  - button is still visible in the UI
  - a message is shown to users  informing, that the download is not available for now
- This is quick fix for the UI side for removing book download option from the app temporarily

## How Can This Be Tested?

- Check the UI
  - check that buttons are still displayed in UI
   - check both book detail view and book lists in collection and My Books 
   - check that message about download disabling is informative
- Test that other book functionalities can be used as before
- Note that some tests are skipped for now

<!--- Leave a comment if your change affects other areas of the code-->

- [ ] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [ ] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [ ] Review added atleast to E-kirjasto maintainers +1
