### PR TITLE
EKIRJASTO-844 Update link in beta banner

### DIFF
--- a/public/locales/en/translations.json
+++ b/public/locales/en/translations.json
@@ -2,7 +2,7 @@
   "auth.unauthorizedMessage": "You need to be signed in to view this page.",
   "badges.ariaLabelForAppStoreLink": "Download E-library on the App Store",
   "badges.ariaLabelForGooglePlayLink": "Get E-library on Google Play",
-  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/en/news/e-library-browser-interface-be-released-21-april",
+  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/en/e-library/try-e-librarys-new-browser-interface",
   "betaBanner.infoAudiobooks": "You can listen to audiobooks in the E-library app.",
   "betaBanner.infoEbooksAndMagazines": "Here you can read Finnish and Swedish e-books and magazines directly in your browser.",
   "betaBanner.infoEkirjasto": "More information about the browser interface",

--- a/public/locales/fi/translations.json
+++ b/public/locales/fi/translations.json
@@ -2,7 +2,7 @@
   "auth.unauthorizedMessage": "Kirjaudu sisään nähdäksesi tämän sivun",
   "badges.ariaLabelForAppStoreLink": "Lataa E-kirjasto App Storesta",
   "badges.ariaLabelForGooglePlayLink": "Lataa E-kirjasto Google Playsta",
-  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/fi/uutiset/e-kirjaston-selainkayttoliittyma-julkaistaan-214",
+  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/fi/e-kirjasto/kokeile-e-kirjaston-selainkayttoliittymaa",
   "betaBanner.infoAudiobooks": "Äänikirjoja voit kuunnella E-kirjasto-sovelluksessa.",
   "betaBanner.infoEbooksAndMagazines": "Täällä voit lukea suomen- ja ruotsinkielisiä e-kirjoja sekä lehtiä suoraan selaimessasi.",
   "betaBanner.infoEkirjasto": "Lisätietoa selainkäyttöliittymästä",

--- a/public/locales/sv/translations.json
+++ b/public/locales/sv/translations.json
@@ -2,7 +2,7 @@
   "auth.unauthorizedMessage": "Du måste logga in för att se den här sidan",
   "badges.ariaLabelForAppStoreLink": "Hämta E-biblioteket i App Store",
   "badges.ariaLabelForGooglePlayLink": "Ladda E-biblioteket ned på Google Play",
-  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/sv/nyheter/e-bibliotekets-webbgranssnitt-publiceras-den-21-april",
+  "betaBanner.hrefInfoEkirjasto": "https://www.kansalliskirjasto.fi/sv/e-kirjasto/kokeile-e-kirjaston-selainkayttoliittymaa",
   "betaBanner.infoAudiobooks": "Du kan lyssna på ljudböcker i E-biblioteket appen.",
   "betaBanner.infoEbooksAndMagazines": "Här kan du läsa finska och svenska e-böcker samt tidskrifter direkt i din webbläsare.",
   "betaBanner.infoEkirjasto": "Mer information om webbgränssnittet",


### PR DESCRIPTION
## Description

- This pull request updates the link in the beta banner of E-kirjasto web app
- The link now opens an info page about the released E-library browser interface and it's current features in beta version
  - previously the link guided user to a news page 

## How can this be tested?

- Start the web application
  - open the link from the banner
   - check that the link opens in a new tab
   - check that the web page that is opened is information page about the E-library browser interface on the NatLibFi website
  - check that the external page is opened in the correct language (based on the locale user has in the web app)

<!--- Leave a comment if your change affects other areas of the code-->

- [ ] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
