### PR TITLE
EKIRJASTO-708 Passkey login retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@natlibfi/ekirjasto-opds-feed-parser": "2.1.0",
         "@nypl/design-system-react-components": "^0.7.2",
         "@nypl/dgx-svg-icons": "^0.3.12",
+        "@simplewebauthn/browser": "^13.3.0",
         "@theme-ui/color": "^0.16.2",
         "@theme-ui/components": "^0.16.2",
         "@theme-ui/match-media": "^0.16.2",
@@ -3558,6 +3559,12 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@natlibfi/ekirjasto-opds-feed-parser": "2.1.0",
         "@nypl/design-system-react-components": "^0.7.2",
         "@nypl/dgx-svg-icons": "^0.3.14",
+        "@simplewebauthn/browser": "^13.3.0",
         "@theme-ui/color": "^0.16.2",
         "@theme-ui/components": "^0.16.2",
         "@theme-ui/match-media": "^0.16.2",
@@ -5333,6 +5334,12 @@
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@natlibfi/ekirjasto-opds-feed-parser": "2.1.0",
     "@nypl/design-system-react-components": "^0.7.2",
     "@nypl/dgx-svg-icons": "^0.3.12",
+    "@simplewebauthn/browser": "^13.3.0",
     "@theme-ui/color": "^0.16.2",
     "@theme-ui/components": "^0.16.2",
     "@theme-ui/match-media": "^0.16.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@natlibfi/ekirjasto-opds-feed-parser": "2.1.0",
     "@nypl/design-system-react-components": "^0.7.2",
     "@nypl/dgx-svg-icons": "^0.3.14",
+    "@simplewebauthn/browser": "^13.3.0",
     "@theme-ui/color": "^0.16.2",
     "@theme-ui/components": "^0.16.2",
     "@theme-ui/match-media": "^0.16.2",

--- a/src/auth/EkirjastoAuthHandler.tsx
+++ b/src/auth/EkirjastoAuthHandler.tsx
@@ -1,8 +1,9 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { Button, jsx } from "theme-ui";
+import { jsx } from "theme-ui";
 import * as React from "react";
 import { ClientEkirjastoMethod } from "interfaces";
+import Button from "components/Button";
 import LoadingIndicator from "components/LoadingIndicator";
 import Stack from "components/Stack";
 import useUser from "components/context/UserContext";
@@ -12,7 +13,7 @@ import { PasskeyLogin } from "./PasskeyLogin";
 
 /**
  * The Ekirjasto Auth handler sends you off to an external website to complete
- * auth.
+ * auth, or user can use passkey
  */
 const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
   method
@@ -39,15 +40,16 @@ const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
   };
 
   return (
-    <Stack direction="column" sx={{ alignItems: "center" }}>
+    <Stack direction="column" spacing={2} sx={{ alignItems: "center" }}>
       {token ? (
         <LoadingIndicator />
       ) : (
         <>
-          <Button onClick={() => handleLogin('strong')}>Login using Suomi.fi</Button>
-          <PasskeyLogin redirectURI = {authSuccessUrl}/>
+          <Button onClick={() => handleLogin()}>Sign in using Suomi.fi</Button>
+          <PasskeyLogin redirectURI={authSuccessUrl} />
         </>
       )}
+      <p>By signing in, you agree to the End User License Agreement</p>
     </Stack>
   );
 };

--- a/src/auth/EkirjastoAuthHandler.tsx
+++ b/src/auth/EkirjastoAuthHandler.tsx
@@ -48,7 +48,6 @@ const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
           <PasskeyLogin redirectURI = {authSuccessUrl}/>
         </>
       )}
-      {!token && <p>Logging in with Ekirjasto Authentication...</p>}
     </Stack>
   );
 };

--- a/src/auth/EkirjastoAuthHandler.tsx
+++ b/src/auth/EkirjastoAuthHandler.tsx
@@ -1,6 +1,6 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { jsx } from "theme-ui";
+import { Button, jsx } from "theme-ui";
 import * as React from "react";
 import { ClientEkirjastoMethod } from "interfaces";
 import LoadingIndicator from "components/LoadingIndicator";
@@ -8,6 +8,7 @@ import Stack from "components/Stack";
 import useUser from "components/context/UserContext";
 import useLoginRedirectUrl from "auth/useLoginRedirect";
 import { clientOnly } from "components/ClientOnly";
+import { PasskeyLogin } from "./PasskeyLogin";
 
 /**
  * The Ekirjasto Auth handler sends you off to an external website to complete
@@ -16,7 +17,7 @@ import { clientOnly } from "components/ClientOnly";
 const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
   method
 }) => {
-  const { token, signOut } = useUser();
+  const { token } = useUser();
   const { authSuccessUrl } = useLoginRedirectUrl();
 
   // Get link for strong authentication
@@ -29,18 +30,25 @@ const EkirjastoAuthHandler: React.FC<{ method: ClientEkirjastoMethod }> = ({
     authSuccessUrl
   )}`;
 
-  // Start login
-  React.useEffect(() => {
+  // Handle button click
+  const handleLogin = async () => {
     if (!token && urlWithRedirect) {
+      // Redirect to login page
       window.location.href = urlWithRedirect;
-      console.log(urlWithRedirect);
     }
-  }, [token, signOut, urlWithRedirect]);
+  };
 
   return (
     <Stack direction="column" sx={{ alignItems: "center" }}>
-      <LoadingIndicator />
-      Logging in with EkirjastoAuthentication...
+      {token ? (
+        <LoadingIndicator />
+      ) : (
+        <>
+          <Button onClick={() => handleLogin('strong')}>Login using Suomi.fi</Button>
+          <PasskeyLogin redirectURI = {authSuccessUrl}/>
+        </>
+      )}
+      {!token && <p>Logging in with Ekirjasto Authentication...</p>}
     </Stack>
   );
 };

--- a/src/auth/LoginWrapper.tsx
+++ b/src/auth/LoginWrapper.tsx
@@ -46,9 +46,9 @@ const LoginWrapper = ({ children }: LoginWrapperProps) => {
       }}
     >
       <Head>
-        <title>Login</title>
+        <title>Sign in</title>
       </Head>
-      <BreadcrumbBar currentLocation="Login" />
+      <BreadcrumbBar currentLocation="Sign in" />
       <div
         sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}
       >
@@ -58,7 +58,7 @@ const LoginWrapper = ({ children }: LoginWrapperProps) => {
         >
           <div sx={{ textAlign: "center", p: 0 }}>
             <H2>{catalogName}</H2>
-            <h4>Login</h4>
+            <h4>Sign in</h4>
           </div>
           {/* when we just become authenticated, we display the
               loading indicator until the page redirects away

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -94,7 +94,7 @@ export function PasskeyCreate() {
   };
 
   if (!isSupported || !method) {
-    return <></>;
+    return <div></div>;
   }
 
   return (

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -1,7 +1,11 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { Button,jsx } from "theme-ui";
-import { browserSupportsWebAuthn, startRegistration } from "@simplewebauthn/browser";
+import { jsx } from "theme-ui";
+import Button from "components/Button";
+import {
+  browserSupportsWebAuthn,
+  startRegistration
+} from "@simplewebauthn/browser";
 import useLibraryContext from "components/context/LibraryContext";
 import { useEffect, useState } from "react";
 import { isSupportedAuthType } from "./AuthenticationHandler";
@@ -9,11 +13,10 @@ import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 import useUser from "components/context/UserContext";
 
 export function PasskeyCreate() {
-    const { authMethods } = useLibraryContext();
-    const { token } = useUser();
+  const { authMethods } = useLibraryContext();
+  const { token } = useUser();
 
-
-    // Get supported methods
+  // Get supported methods
   const supportedAuthMethods = authMethods.filter(m =>
     isSupportedAuthType(m.type)
   );
@@ -30,7 +33,6 @@ export function PasskeyCreate() {
   const passkeyRegisterFinishHref = method.links?.find(
     link => link.rel === "passkey_register_finish"
   )?.href;
-
 
   const [isSupported, setIsSupported] = useState(false);
   const [error, setError] = useState("");
@@ -51,24 +53,20 @@ export function PasskeyCreate() {
         headers: {
           accept: "application/json",
           "content-type": "application/json",
-          authorization: token!,
-
+          authorization: token!
         },
-        body: JSON.stringify({"username": ""}),
+        body: JSON.stringify({ username: "" })
       });
 
       if (!startResponse.ok) {
         throw new Error("Failed to start passkey registeration");
       }
 
-      //OK!
       const { publicKey } = await startResponse.json();
 
       // Step 2: Start the passkey registration using the options we received from the start
-      //OK!
       const data = await startRegistration({ optionsJSON: publicKey });
 
-      
       // Step 3: Submit the registration response via a POST form
 
       const finishResponse = await fetch(passkeyRegisterFinishHref!, {
@@ -76,19 +74,17 @@ export function PasskeyCreate() {
         headers: {
           accept: "application/json",
           "content-type": "application/json",
-          authorization: token!,
-
+          authorization: token!
         },
-        body: JSON.stringify(data),
+        body: JSON.stringify(data)
       });
 
       if (!finishResponse.ok) {
         throw new Error("Failed to finish passkey registeration");
       }
 
-      const response = await finishResponse.json()
+      const response = await finishResponse.json();
       //TODO: do something with the response, or just inform that successful
-
     } catch (err) {
       setError((err as Error).message || "Passkey creation failed");
       setIsLoading(false);
@@ -96,15 +92,20 @@ export function PasskeyCreate() {
   };
 
   if (!isSupported) {
-    return <p>Passkeys are not supported in this browser.</p>;
+    return;
   }
 
   return (
     <div>
-      <Button onClick={handleLogin} disabled={isLoading}>
-        {isLoading ? "Authenticating…" : "Create a passkey"}
+      <Button
+        variant="ghost"
+        color="ui.black"
+        onClick={handleCreate}
+        disabled={isLoading}
+      >
+        {isLoading ? "Authenticating…" : "Register a passkey"}
       </Button>
-        {error && <p style={{ color: "red" }}>{error}</p>}
+      {error && <p style={{ color: "red" }}>{error}</p>}
     </div>
   );
 }

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -83,7 +83,7 @@ export function PasskeyCreate() {
         throw new Error("Failed to finish passkey registeration");
       }
 
-      const response = await finishResponse.json();
+      await finishResponse.json();
       //TODO: do something with the response, or just inform that successful
     } catch (err) {
       setError((err as Error).message || "Passkey creation failed");

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -21,18 +21,18 @@ export function PasskeyCreate() {
     isSupportedAuthType(m.type)
   );
 
-  // Get ekirjasto auth methog
+  // Get ekirjasto auth method
   const method = supportedAuthMethods.find(
     method => method.type === EKIRJASTO_AUTH_TYPE
   )!;
 
-  const passkeyRegisterStartHref = method.links?.find(
-    link => link.rel === "passkey_register_start"
-  )?.href;
+  const passkeyRegisterStartHref = method
+    ? method.links?.find(link => link.rel === "passkey_register_start")?.href
+    : undefined;
 
-  const passkeyRegisterFinishHref = method.links?.find(
-    link => link.rel === "passkey_register_finish"
-  )?.href;
+  const passkeyRegisterFinishHref = method
+    ? method.links?.find(link => link.rel === "passkey_register_finish")?.href
+    : undefined;
 
   const [isSupported, setIsSupported] = useState(false);
   const [error, setError] = useState("");
@@ -46,53 +46,55 @@ export function PasskeyCreate() {
     setError("");
     setIsLoading(true);
 
-    try {
-      // Step 1: Request a challenge from the server
-      const startResponse = await fetch(passkeyRegisterStartHref!, {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          authorization: token!
-        },
-        body: JSON.stringify({ username: "" })
-      });
+    if (passkeyRegisterStartHref && passkeyRegisterFinishHref) {
+      try {
+        // Step 1: Request a challenge from the server
+        const startResponse = await fetch(passkeyRegisterStartHref, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            authorization: token!
+          },
+          body: JSON.stringify({ username: "" })
+        });
 
-      if (!startResponse.ok) {
-        throw new Error("Failed to start passkey registeration");
+        if (!startResponse.ok) {
+          throw new Error("Failed to start passkey registeration");
+        }
+
+        const { publicKey } = await startResponse.json();
+
+        // Step 2: Start the passkey registration using the options we received from the start
+        const data = await startRegistration({ optionsJSON: publicKey });
+
+        // Step 3: Submit the registration response via a POST form
+
+        const finishResponse = await fetch(passkeyRegisterFinishHref, {
+          method: "POST",
+          headers: {
+            accept: "application/json",
+            "content-type": "application/json",
+            authorization: token!
+          },
+          body: JSON.stringify(data)
+        });
+
+        if (!finishResponse.ok) {
+          throw new Error("Failed to finish passkey registeration");
+        }
+
+        await finishResponse.json();
+        //TODO: do something with the response, or just inform that successful
+      } catch (err) {
+        setError((err as Error).message || "Passkey creation failed");
+        setIsLoading(false);
       }
-
-      const { publicKey } = await startResponse.json();
-
-      // Step 2: Start the passkey registration using the options we received from the start
-      const data = await startRegistration({ optionsJSON: publicKey });
-
-      // Step 3: Submit the registration response via a POST form
-
-      const finishResponse = await fetch(passkeyRegisterFinishHref!, {
-        method: "POST",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          authorization: token!
-        },
-        body: JSON.stringify(data)
-      });
-
-      if (!finishResponse.ok) {
-        throw new Error("Failed to finish passkey registeration");
-      }
-
-      await finishResponse.json();
-      //TODO: do something with the response, or just inform that successful
-    } catch (err) {
-      setError((err as Error).message || "Passkey creation failed");
-      setIsLoading(false);
     }
   };
 
-  if (!isSupported) {
-    return;
+  if (!isSupported || !method) {
+    return <></>;
   }
 
   return (

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -1,0 +1,110 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { Button,jsx } from "theme-ui";
+import { browserSupportsWebAuthn, startRegistration } from "@simplewebauthn/browser";
+import useLibraryContext from "components/context/LibraryContext";
+import { useEffect, useState } from "react";
+import { isSupportedAuthType } from "./AuthenticationHandler";
+import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
+import useUser from "components/context/UserContext";
+
+export function PasskeyCreate() {
+    const { authMethods } = useLibraryContext();
+    const { token } = useUser();
+
+
+    // Get supported methods
+  const supportedAuthMethods = authMethods.filter(m =>
+    isSupportedAuthType(m.type)
+  );
+
+  // Get ekirjasto auth methog
+  const method = supportedAuthMethods.find(
+    method => method.type === EKIRJASTO_AUTH_TYPE
+  )!;
+
+  const passkeyRegisterStartHref = method.links?.find(
+    link => link.rel === "passkey_register_start"
+  )?.href;
+
+  const passkeyRegisterFinishHref = method.links?.find(
+    link => link.rel === "passkey_register_finish"
+  )?.href;
+
+
+  const [isSupported, setIsSupported] = useState(false);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsSupported(browserSupportsWebAuthn());
+  }, []);
+
+  const handleLogin = async () => {
+    setError("");
+    setIsLoading(true);
+
+    try {
+      // Step 1: Request a challenge from the server
+      const startResponse = await fetch(passkeyRegisterStartHref!, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          authorization: token!,
+
+        },
+        body: JSON.stringify({"username": ""}),
+      });
+
+      if (!startResponse.ok) {
+        throw new Error("Failed to start passkey registeration");
+      }
+
+      //OK!
+      const { publicKey } = await startResponse.json();
+
+      // Step 2: Start the passkey registration using the options we received from the start
+      //OK!
+      const data = await startRegistration({ optionsJSON: publicKey });
+
+      
+      // Step 3: Submit the registration response via a POST form
+
+      const finishResponse = await fetch(passkeyRegisterFinishHref!, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+          authorization: token!,
+
+        },
+        body: JSON.stringify(data),
+      });
+
+      if (!finishResponse.ok) {
+        throw new Error("Failed to finish passkey registeration");
+      }
+
+      const response = await finishResponse.json()
+      //TODO: do something with the response, or just informa that successful
+
+    } catch (err) {
+      setError((err as Error).message || "Passkey creation failed");
+      setIsLoading(false);
+    }
+  };
+
+  if (!isSupported) {
+    return <p>Passkeys are not supported in this browser.</p>;
+  }
+
+  return (
+    <div>
+      <Button onClick={handleLogin} disabled={isLoading}>
+        {isLoading ? "Authenticating…" : "Create a passkey"}
+      </Button>
+        {error && <p style={{ color: "red" }}>{error}</p>}
+    </div>
+  );
+}

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -40,7 +40,7 @@ export function PasskeyCreate() {
     setIsSupported(browserSupportsWebAuthn());
   }, []);
 
-  const handleLogin = async () => {
+  const handleCreate = async () => {
     setError("");
     setIsLoading(true);
 
@@ -87,7 +87,7 @@ export function PasskeyCreate() {
       }
 
       const response = await finishResponse.json()
-      //TODO: do something with the response, or just informa that successful
+      //TODO: do something with the response, or just inform that successful
 
     } catch (err) {
       setError((err as Error).message || "Passkey creation failed");

--- a/src/auth/PasskeyLogin.tsx
+++ b/src/auth/PasskeyLogin.tsx
@@ -73,9 +73,10 @@ export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
       const input = document.createElement("input");
       input.type = "hidden";
       input.name = "json";
+      // Ignore lint error for this one line, as the server needs the value to be redirect_uri
+      // eslint-disable-next-line camelcase
       input.value = JSON.stringify({ data, redirect_uri: redirectURI });
       form.appendChild(input);
-
       document.body.appendChild(form);
       form.submit();
     } catch (err) {

--- a/src/auth/PasskeyLogin.tsx
+++ b/src/auth/PasskeyLogin.tsx
@@ -1,0 +1,101 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { Button,jsx } from "theme-ui";
+import { browserSupportsWebAuthn, startAuthentication } from "@simplewebauthn/browser";
+import useLibraryContext from "components/context/LibraryContext";
+import { useEffect, useState } from "react";
+import { isSupportedAuthType } from "./AuthenticationHandler";
+import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
+import useLoginRedirectUrl from "./useLoginRedirect";
+import useUser from "components/context/UserContext";
+
+
+export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
+
+     const { authMethods } = useLibraryContext();
+    
+        // Get supported methods
+      const supportedAuthMethods = authMethods.filter(m =>
+        isSupportedAuthType(m.type)
+      );
+    
+      // Get ekirjasto auth methog
+      const method = supportedAuthMethods.find(
+        method => method.type === EKIRJASTO_AUTH_TYPE
+      )!;
+    
+      const passkeyLoginStartHref = method.links?.find(
+        link => link.rel === "passkey_login_start"
+      )?.href;
+    
+      const passkeyLoginFinishHref = method.links?.find(
+        link => link.rel === "passkey_login_finish"
+      )?.href;
+    
+    
+  const [isSupported, setIsSupported] = useState(false);
+  const [error, setError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    setIsSupported(browserSupportsWebAuthn());
+  }, []);
+
+  const handleLogin = async () => {
+    setError("");
+    setIsLoading(true);
+
+    try {
+      // Step 1: Request a challenge from the server
+      const startResponse = await fetch(passkeyLoginStartHref!, {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (!startResponse.ok) {
+        throw new Error("Failed to start passkey authentication");
+      }
+
+      const { publicKey } = await startResponse.json();
+
+      // Step 2: Prompt the user to authenticate with their passkey
+      const data = await startAuthentication({ optionsJSON: publicKey });
+
+      // Step 3: Submit the authentication response via a POST form
+      const form = document.createElement("form");
+      form.style.display = "none";
+      form.method = "post";
+      form.action =passkeyLoginFinishHref!;
+
+      const input = document.createElement("input");
+      input.type = "hidden";
+      input.name = "json";
+      input.value = JSON.stringify({ data, redirect_uri: redirectURI });
+      form.appendChild(input);
+
+      document.body.appendChild(form);
+      form.submit();
+    } catch (err) {
+      setError((err as Error).message || "Authentication failed");
+      setIsLoading(false);
+    }
+  };
+
+  if (!isSupported) {
+    return <p>Passkeys are not supported in this browser.</p>;
+  }
+
+  return (
+    <div>
+      <button onClick={handleLogin} disabled={isLoading}>
+        {isLoading ? "Authenticating…" : "Sign in with a passkey"}
+      </button>
+      {error && <p style={{ color: "red" }}>{error}</p>}
+    </div>
+  );
+}
+

--- a/src/auth/PasskeyLogin.tsx
+++ b/src/auth/PasskeyLogin.tsx
@@ -1,36 +1,37 @@
 /** @jsxRuntime classic */
 /** @jsx jsx */
-import { Button,jsx } from "theme-ui";
-import { browserSupportsWebAuthn, startAuthentication } from "@simplewebauthn/browser";
+import { jsx } from "theme-ui";
+import Button from "components/Button";
+import {
+  browserSupportsWebAuthn,
+  startAuthentication
+} from "@simplewebauthn/browser";
 import useLibraryContext from "components/context/LibraryContext";
 import { useEffect, useState } from "react";
 import { isSupportedAuthType } from "./AuthenticationHandler";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
 
-
 export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
+  const { authMethods } = useLibraryContext();
 
-     const { authMethods } = useLibraryContext();
-    
-        // Get supported methods
-      const supportedAuthMethods = authMethods.filter(m =>
-        isSupportedAuthType(m.type)
-      );
-    
-      // Get ekirjasto auth methog
-      const method = supportedAuthMethods.find(
-        method => method.type === EKIRJASTO_AUTH_TYPE
-      )!;
-    
-      const passkeyLoginStartHref = method.links?.find(
-        link => link.rel === "passkey_login_start"
-      )?.href;
-    
-      const passkeyLoginFinishHref = method.links?.find(
-        link => link.rel === "passkey_login_finish"
-      )?.href;
-    
-    
+  // Get supported methods
+  const supportedAuthMethods = authMethods.filter(m =>
+    isSupportedAuthType(m.type)
+  );
+
+  // Get ekirjasto auth method
+  const method = supportedAuthMethods.find(
+    method => method.type === EKIRJASTO_AUTH_TYPE
+  )!;
+
+  const passkeyLoginStartHref = method.links?.find(
+    link => link.rel === "passkey_login_start"
+  )?.href;
+
+  const passkeyLoginFinishHref = method.links?.find(
+    link => link.rel === "passkey_login_finish"
+  )?.href;
+
   const [isSupported, setIsSupported] = useState(false);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -49,9 +50,9 @@ export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
         method: "POST",
         headers: {
           accept: "application/json",
-          "content-type": "application/json",
+          "content-type": "application/json"
         },
-        body: JSON.stringify({}),
+        body: JSON.stringify({})
       });
 
       if (!startResponse.ok) {
@@ -67,7 +68,7 @@ export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
       const form = document.createElement("form");
       form.style.display = "none";
       form.method = "post";
-      form.action =passkeyLoginFinishHref!;
+      form.action = passkeyLoginFinishHref!;
 
       const input = document.createElement("input");
       input.type = "hidden";
@@ -89,11 +90,10 @@ export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {
 
   return (
     <div>
-      <button onClick={handleLogin} disabled={isLoading}>
+      <Button onClick={handleLogin} disabled={isLoading}>
         {isLoading ? "Authenticating…" : "Sign in with a passkey"}
-      </button>
+      </Button>
       {error && <p style={{ color: "red" }}>{error}</p>}
     </div>
   );
 }
-

--- a/src/auth/PasskeyLogin.tsx
+++ b/src/auth/PasskeyLogin.tsx
@@ -6,8 +6,6 @@ import useLibraryContext from "components/context/LibraryContext";
 import { useEffect, useState } from "react";
 import { isSupportedAuthType } from "./AuthenticationHandler";
 import { EKIRJASTO_AUTH_TYPE } from "utils/constants";
-import useLoginRedirectUrl from "./useLoginRedirect";
-import useUser from "components/context/UserContext";
 
 
 export function PasskeyLogin({ redirectURI }: { redirectURI?: string }) {

--- a/src/auth/__tests__/LoginWrapper.test.tsx
+++ b/src/auth/__tests__/LoginWrapper.test.tsx
@@ -5,12 +5,12 @@ import { mockPush } from "test-utils/mockNextRouter";
 
 test("renders header, subheader, and breadcrumbs", () => {
   const utils = render(<LoginWrapper />);
-  expect(utils.getByRole("heading", { name: "Login" })).toBeInTheDocument();
+  expect(utils.getByRole("heading", { name: "Sign in" })).toBeInTheDocument();
   expect(
     utils.getByRole("heading", { name: "XYZ Public Library" })
   ).toBeInTheDocument();
   expect(
-    utils.getByRole("listitem", { name: "Current location: Login" })
+    utils.getByRole("listitem", { name: "Current location: Sign in" })
   ).toBeInTheDocument();
   expect(
     utils.getByRole("link", { name: "XYZ Public Library" })

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,7 @@ import Stack from "./Stack";
 import { SignOut } from "./SignOut";
 import useUser from "components/context/UserContext";
 import useLogin from "auth/useLogin";
+import { PasskeyCreate } from "auth/PasskeyCreate";
 import { useTranslation } from "next-i18next";
 import LanguageSelector from "components/LanguageSelector";
 
@@ -148,7 +149,10 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
         My Books
       </NavButton>
       {isAuthenticated ? (
+        <div>
+        <PasskeyCreate />
         <SignOut />
+        </div>
       ) : isLoading ? (
         <Button loading />
       ) : (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,7 +4,7 @@ import { jsx } from "theme-ui";
 import * as React from "react";
 import { LibraryData } from "../interfaces";
 import Search from "./Search";
-import Button, { NavButton, AnchorButton } from "./Button";
+import Button, { NavButton, AnchorButton } from "../components/Button";
 import BrowseIcon from "../icons/Browse";
 import MagazinesIcon from "../icons/Magazines";
 import MyBooksIcon from "../icons/MyBooks";
@@ -133,8 +133,8 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
 
       {isAuthenticated ? (
         <div>
-        <PasskeyCreate />
-        <SignOut />
+          <PasskeyCreate />
+          <SignOut />
         </div>
       ) : isLoading ? (
         <Button loading />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { jsx } from "theme-ui";
 import * as React from "react";
 import { LibraryData } from "../interfaces";
 import Search from "./Search";
-import Button, { NavButton, AnchorButton } from "./Button";
+import Button, { NavButton, AnchorButton } from "../components/Button";
 import Link from "./Link";
 import BookIcon from "../icons/Book";
 import useLibraryContext from "./context/LibraryContext";
@@ -150,8 +150,8 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
       </NavButton>
       {isAuthenticated ? (
         <div>
-        <PasskeyCreate />
-        <SignOut />
+          <PasskeyCreate />
+          <SignOut />
         </div>
       ) : isLoading ? (
         <Button loading />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -13,6 +13,7 @@ import Stack from "./Stack";
 import { SignOut } from "./SignOut";
 import useUser from "components/context/UserContext";
 import useLogin from "auth/useLogin";
+import { PasskeyCreate } from "auth/PasskeyCreate";
 import { useTranslation } from "next-i18next";
 import LanguageSelector from "components/LanguageSelector";
 import EkirjastoHeaderLogo from "components/logosAndBadges/EkirjastoHeaderLogo";
@@ -131,7 +132,10 @@ const HeaderLinks: React.FC<{ library: LibraryData }> = ({ library }) => {
       )}
 
       {isAuthenticated ? (
+        <div>
+        <PasskeyCreate />
         <SignOut />
+        </div>
       ) : isLoading ? (
         <Button loading />
       ) : (


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

This pr adds the implementation of passkey as a login method. This includes a new login view where you can choose login method, as well as a "Register a passkey" button in top button row, visible when logged in and supported by the browser.

To implement this, we used simplewebauthn/browser.

Logging in with the passkey should redirect to the same endpoint as the Suomi.fi login.
If the browser doesn't support passkey, in the login view the user is informed of that, and the "register passkey" button is not shown.

Translations still need to be done.

This pr is copy of the previous one.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

NOTE: When tested locally, both creating a passkey, and logging in with it causes an error because of the domain. So actual testing needs to be done in dev.

Check that:
- There is a new button for registering a passkey when logged in
- Logging in opens a new view where there are the options of Suomi.fi and passkey
- That Suomi.fi login still works

<!--- Leave a comment if your change affects other areas of the code-->

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1

