### PR TITLE
EKIRJASTO-708 Add username and data to passkey create finish request

### DIFF
--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -68,6 +68,12 @@ export function PasskeyCreate() {
         // Step 2: Start the passkey registration using the options we received from the start
         const data = await startRegistration({ optionsJSON: publicKey });
 
+        // Add expected username to the body
+        const body = {
+          username: "",
+          data: data
+        }
+
         // Step 3: Submit the registration response via a POST form
 
         const finishResponse = await fetch(passkeyRegisterFinishHref, {
@@ -77,7 +83,7 @@ export function PasskeyCreate() {
             "content-type": "application/json",
             authorization: token!
           },
-          body: JSON.stringify(data)
+          body: JSON.stringify(body)
         });
 
         if (!finishResponse.ok) {

--- a/src/auth/PasskeyCreate.tsx
+++ b/src/auth/PasskeyCreate.tsx
@@ -72,7 +72,7 @@ export function PasskeyCreate() {
         const body = {
           username: "",
           data: data
-        }
+        };
 
         // Step 3: Submit the registration response via a POST form
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->
The finishing of passkey creation fails, so this attempts to fix that.

We add into the request body an empty username field and add the data to a field named data.
## How Can This Be Tested?

- [x] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->
This can not be tested locally, since the request fails earlier locally.
<!--- Leave a comment if your change affects other areas of the code-->
This
- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1