### PR TITLE
EKIRJASTO-884 Web reader fixes

### DIFF
--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -1,3 +1,6 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import { jsx } from "theme-ui";
 import * as React from "react";
 import {
   AnyFullfillment,
@@ -18,7 +21,6 @@ import downloadFile from "dataflow/download";
 import useError from "hooks/useError";
 import useLinkUtils from "hooks/useLinkUtils";
 import { useTranslation } from "next-i18next";
-import Stack from "./Stack";
 
 const FulfillmentButton: React.FC<{
   details: AnyFullfillment;
@@ -103,7 +105,7 @@ const ReadOnlineExternal: React.FC<{
     }
   }
   return (
-    <Stack sx={{ flexWrap: "wrap" }}>
+    <>
       <Button
         {...getButtonStyles(isPrimaryAction)}
         iconLeft={SvgExternalLink}
@@ -114,7 +116,7 @@ const ReadOnlineExternal: React.FC<{
         {t(details.buttonLabel)}
       </Button>
       {error && <Text sx={{ color: "ui.error" }}>{error}</Text>}
-    </Stack>
+    </>
   );
 };
 

--- a/src/components/FulfillmentButton.tsx
+++ b/src/components/FulfillmentButton.tsx
@@ -1,6 +1,3 @@
-/** @jsxRuntime classic */
-/** @jsx jsx */
-import { jsx } from "theme-ui";
 import * as React from "react";
 import {
   AnyFullfillment,
@@ -11,7 +8,7 @@ import {
 import { FulfillableBook } from "interfaces";
 import track from "analytics/track";
 import SvgDownload from "icons/Download";
-import ArrowForward from "icons/ArrowForward";
+import SvgExternalLink from "icons/ExternalOpen";
 import { useRouter } from "next/router";
 import { Text } from "components/Text";
 import Button from "components/Button";
@@ -21,6 +18,7 @@ import downloadFile from "dataflow/download";
 import useError from "hooks/useError";
 import useLinkUtils from "hooks/useLinkUtils";
 import { useTranslation } from "next-i18next";
+import Stack from "./Stack";
 
 const FulfillmentButton: React.FC<{
   details: AnyFullfillment;
@@ -97,17 +95,18 @@ const ReadOnlineExternal: React.FC<{
 
       // we are about to open the book, so send a track event
       track.openBook(trackOpenBookUrl);
-      window.open(externalReaderUrl, "_self");
+      setLoading(false);
+      window.open(externalReaderUrl);
     } catch (e) {
       setLoading(false);
       handleError(e);
     }
   }
   return (
-    <>
+    <Stack sx={{ flexWrap: "wrap" }}>
       <Button
         {...getButtonStyles(isPrimaryAction)}
-        iconLeft={ArrowForward}
+        iconLeft={SvgExternalLink}
         onClick={open}
         loading={loading}
         loadingText={t("fulfillmentButton.opening")}
@@ -115,7 +114,7 @@ const ReadOnlineExternal: React.FC<{
         {t(details.buttonLabel)}
       </Button>
       {error && <Text sx={{ color: "ui.error" }}>{error}</Text>}
-    </>
+    </Stack>
   );
 };
 

--- a/src/components/bookDetails/FulfillmentCard.tsx
+++ b/src/components/bookDetails/FulfillmentCard.tsx
@@ -84,27 +84,55 @@ const AccessCard: React.FC<{
 }> = ({ book, links }) => {
   const fulfillments = getFulfillmentsFromBook(book);
 
-  const isFulfillable = fulfillments.length > 0;
+  // visually prioritize internal fulfillments (mirrors apps)
+  const internalFulfillments = fulfillments.filter(
+    details => details.type === "read-online-internal"
+  );
+  const otherFulfillments = fulfillments.filter(
+    details => details.type !== "read-online-internal"
+  );
+
+  const isFulfillableInternally = internalFulfillments.length > 0;
+  const hasOtherFulfillments = otherFulfillments.length > 0;
   const redirectUser = shouldRedirectToCompanionApp(links);
 
   const { t } = useTranslation();
 
   return (
     <>
-      <CancelOrReturn
-        url={book.revokeUrl}
-        loadingText={t("bookDetails.returning")}
-        id={book.id}
-        text={t("bookDetails.return")}
-      />
-      {isFulfillable && redirectUser && (
+      {isFulfillableInternally ? (
+        <Stack sx={{ flexWrap: "wrap" }}>
+          {internalFulfillments.map(details => (
+            <FulfillmentButton
+              isPrimaryAction
+              key={details.id}
+              details={details}
+              book={book}
+            />
+          ))}
+          <CancelOrReturn
+            url={book.revokeUrl}
+            loadingText={t("bookDetails.returning")}
+            id={book.id}
+            text={t("bookDetails.return")}
+          />
+        </Stack>
+      ) : (
+        <CancelOrReturn
+          url={book.revokeUrl}
+          loadingText={t("bookDetails.returning")}
+          id={book.id}
+          text={t("bookDetails.return")}
+        />
+      )}
+      {hasOtherFulfillments && redirectUser && (
         <Text variant="text.body.italic">
           {t("bookDetails.readOnComputer")}
         </Text>
       )}
-      {isFulfillable && (
+      {hasOtherFulfillments && (
         <Stack sx={{ flexWrap: "wrap" }}>
-          {fulfillments.map(details => (
+          {otherFulfillments.map(details => (
             <FulfillmentButton
               key={details.id}
               details={details}


### PR DESCRIPTION
## Description
This pr changes the visual look of the read online button in a minor way.

The arrow in the button is switched to an external link icon.

The read online link now opens to another tab.

## How Can This Be Tested?

- [ ] This change cannot be tested visually
<!--- Please describe in detail how one can test this -->

<!--- Leave a comment if your change affects other areas of the code-->
Check what the button for read online looks like. Pressing the button should switch to another tab and open the book.
NOTE: Does not work correctly for demarque books yet, needs changes to circulation manager

- [x] Tested locally
- [ ] Tested on a mobile device
- [ ] Tested with Firefox
- [x] Tested with Chrome
- [ ] Tested with Edge
- [ ] Tested with Safari

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] Review added atleast to E-kirjasto maintainers +1
